### PR TITLE
[WIP] Create the mongodb database with user

### DIFF
--- a/spec/acceptance/pulp_db_auth_spec.rb
+++ b/spec/acceptance/pulp_db_auth_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper_acceptance'
+
+describe 'Scenario: install pulp with authenticated mongodb' do
+  let(:pp) do
+    <<-EOS
+    class { '::mongodb::server':
+      auth           => true,
+      create_admin   => true,
+      admin_password => 'supersecret',
+      store_creds    => true,
+    } ->
+    class { '::pulp':
+      manage_repo  => true,
+      db_username  => 'pulp',
+      db_password  => 'secret',
+      # https://github.com/Katello/puppet-pulp/issues/138
+      ssl_username => '',
+      enable_admin => true,
+    }
+
+    pulp_isorepo { 'DataMonster':
+    }
+    EOS
+  end
+
+  it_behaves_like 'a idempotent resource'
+
+  ['httpd', 'mongod', 'pulp_celerybeat', 'pulp_workers', 'pulp_resource_manager', 'pulp_streamer'].each do |service_name|
+    describe service(service_name) do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+  end
+
+  describe port(80) do
+    it { is_expected.to be_listening }
+  end
+
+  describe port(443) do
+    it { is_expected.to be_listening }
+  end
+
+  describe command('pulp-admin status') do
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+
+  describe command('pulp-admin repo list') do
+    its(:exit_status) { is_expected.to eq 0 }
+    its(:stdout) { is_expected.to include 'DataMonster' }
+  end
+end

--- a/spec/classes/pulp_database_spec.rb
+++ b/spec/classes/pulp_database_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe 'pulp::database' do
+  on_os_under_test.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      context 'with explicit parameters' do
+        context 'with database' do
+          let :params do
+            {
+              :manage_db       => true,
+              :database        => 'dpulp',
+              :username        => 'upulp',
+              :password        => 'pass',
+              :migrate_timeout => 100,
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('mongodb::server') }
+          it { is_expected.to contain_mongodb_database('dpulp') }
+
+          it do
+            is_expected.to contain_mongodb_user('upulp')
+              .with_password('pass')
+              .that_requires('Mongodb_database[dpulp]')
+          end
+
+          it do
+            is_expected.to contain_exec('migrate_pulp_db')
+              .with_timeout(100)
+              .that_requires(['Mongodb_database[dpulp]', 'Mongodb_user[upulp]'])
+          end
+        end
+
+        context 'with database' do
+          let :params do
+            {
+              :manage_db       => false,
+              :database        => 'dpulp',
+              :username        => 'upulp',
+              :password        => 'pass',
+              :migrate_timeout => 100,
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.not_to contain_class('mongodb::server') }
+          it { is_expected.not_to contain_mongodb_database('dpulp') }
+          it { is_expected.not_to contain_mongodb_user('upulp') }
+          it { is_expected.to contain_exec('migrate_pulp_db').with_timeout(100) }
+        end
+      end
+
+      context 'with inherited parameters' do
+        let :pre_condition do
+          'include ::pulp'
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('mongodb::server') }
+        it { is_expected.to contain_mongodb_database('pulp_database') }
+        it { is_expected.not_to contain_mongodb_user('pulp') }
+
+        it do
+          is_expected.to contain_exec('migrate_pulp_db')
+            .with_timeout(300)
+            .that_requires('Mongodb_database[pulp_database]')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously we only stored the username/password but didn't actually enforce it. By default mongodb doesn't enforce permissions but if a user configured it to do so, then they would need to manually configure the database.

Currently broken. Needs at least https://github.com/puppetlabs/puppetlabs-mongodb/pull/393 but possibly more.

Closes GH-199