### PR TITLE
different ca certificate for apache and pulp

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -82,7 +82,7 @@ class pulp::apache {
       ssl_cert                   => $::pulp::https_cert,
       ssl_key                    => $::pulp::https_key,
       ssl_chain                  => $::pulp::https_chain,
-      ssl_ca                     => $::pulp::ca_cert,
+      ssl_ca                     => pick($::pulp::https_ca_cert, $::pulp::ca_cert),
       ssl_certs_dir              => '',
       ssl_verify_client          => 'optional',
       ssl_protocol               => $::pulp::ssl_protocol,

--- a/manifests/child/apache.pp
+++ b/manifests/child/apache.pp
@@ -2,7 +2,7 @@ class pulp::child::apache (
   $servername = $::fqdn,
   $ssl_cert = $::pulp::child::ssl_cert,
   $ssl_key = $::pulp::child::ssl_key,
-  $ssl_ca = $::pulp::ca_cert,
+  $ssl_ca = $::pulp::https_ca_cert,
   $max_keep_alive = $::pulp::max_keep_alive,
   $ssl_username = $::pulp::ssl_username,
 ) {
@@ -18,6 +18,12 @@ class pulp::child::apache (
     $directories = undef
   }
 
+  if $ssl_ca {
+    $_ssl_ca = $ssl_ca
+  } else {
+    $_ssl_ca = $::pulp::ca_cert
+  }
+
   apache::vhost { 'pulp-node-ssl':
     servername             => $servername,
     docroot                => '/var/www/html',
@@ -29,7 +35,7 @@ class pulp::child::apache (
     ssl                    => true,
     ssl_cert               => $ssl_cert,
     ssl_key                => $ssl_key,
-    ssl_ca                 => $ssl_ca,
+    ssl_ca                 => $_ssl_ca,
     ssl_certs_dir          => '',
     ssl_verify_client      => 'optional',
     ssl_options            => '+StdEnvVars',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,6 +104,8 @@
 #
 # $https_chain::                apache chain file for ssl
 #
+# $https_ca_cert::              apache ca cert file for ssl, falls back to ca_cert if empty
+#
 # $ssl_username::               Value to use for SSLUsername directive in apache vhost. Defaults to SSL_CLIENT_S_DN_CN.
 #                               Set an empty string or false to unset directive.
 #
@@ -294,6 +296,7 @@ class pulp (
   Optional[Stdlib::Absolutepath] $https_cert = $::pulp::params::https_cert,
   Optional[Stdlib::Absolutepath] $https_key = $::pulp::params::https_key,
   Optional[Stdlib::Absolutepath] $https_chain = $::pulp::params::https_chain,
+  Optional[Stdlib::Absolutepath] $https_ca_cert = $::pulp::params::https_ca_cert,
   Variant[String, Boolean] $ssl_username = $::pulp::params::ssl_username,
   Integer $user_cert_expiration = $::pulp::params::user_cert_expiration,
   Integer $consumer_cert_expiration = $::pulp::params::consumer_cert_expiration,
@@ -396,7 +399,7 @@ class pulp (
     class { '::pulp::crane':
       cert     => $https_cert,
       key      => $https_key,
-      ca_cert  => $ca_cert,
+      ca_cert  => pick($https_ca_cert, $ca_cert),
       port     => $crane_port,
       data_dir => $crane_data_dir,
       debug    => $crane_debug,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,6 +57,7 @@ class pulp::params {
   $https_cert = $ca_cert
   $https_key = $ca_key
   $https_chain = undef
+  $https_ca_cert = undef
   $ssl_username = 'SSL_CLIENT_S_DN_CN'
   $enable_http = false
   $ssl_verify_client = 'require'

--- a/spec/classes/pulp_apache_spec.rb
+++ b/spec/classes/pulp_apache_spec.rb
@@ -33,6 +33,10 @@ describe 'pulp::apache' do
         :serveraliases           => [facts[:hostname]],
         :docroot                 => '/usr/share/pulp/wsgi',
         :ssl                     => true,
+        :ssl_cert                => '/etc/pki/pulp/ca.crt',
+        :ssl_key                 => '/etc/pki/pulp/ca.key',
+        :ssl_chain               => nil,
+        :ssl_ca                  => '/etc/pki/pulp/ca.crt',
         :ssl_verify_client       => 'optional',
         :ssl_protocol            => ['all', '-SSLv2', '-SSLv3'],
         :ssl_options             => '+StdEnvVars +ExportCertData',
@@ -42,6 +46,27 @@ describe 'pulp::apache' do
         :wsgi_daemon_process     => 'pulp user=apache group=apache processes=3 maximum-requests=0 display-name=%{GROUP}',
         :wsgi_pass_authorization => 'On',
         :wsgi_import_script      => '/usr/share/pulp/wsgi/webservices.wsgi',
+      })
+    end
+  end
+
+  context 'with https_ca_cert on ::pulp class set' do
+    let :pre_condition do
+      "class { 'pulp':
+        https_ca_cert => '/path/to/ca.crt',
+      }"
+    end
+
+    let :facts do
+      default_facts
+    end
+
+    it 'should configure apache server with ssl' do
+      is_expected.to contain_apache__vhost('pulp-https').with({
+        :ssl_cert  => '/etc/pki/pulp/ca.crt',
+        :ssl_key   => '/etc/pki/pulp/ca.key',
+        :ssl_chain => nil,
+        :ssl_ca    => '/path/to/ca.crt',
       })
     end
   end

--- a/spec/classes/pulp_child_apache_spec.rb
+++ b/spec/classes/pulp_child_apache_spec.rb
@@ -22,9 +22,14 @@ describe 'pulp::child::apache' do
             .with_servername('foo.example.com')
             .with_ssl_cert('/etc/pki/pulp/ssl_apache.crt')
             .with_ssl_key('/etc/pki/pulp/ssl_apache.key')
-            .with_ssl_ca('/etc/pki/pulp/ca.crt')
+            .with_ssl_ca(nil)
             .with_max_keep_alive(10000)
             .with_ssl_username('SSL_CLIENT_S_DN_CN')
+        end
+
+        it do
+          is_expected.to contain_apache__vhost('pulp-node-ssl')
+            .with_ssl_ca('/etc/pki/pulp/ca.crt')
         end
       end
 


### PR DESCRIPTION
This PR exposes a new parameter `https_ca_cert` to allow you to use a different ca certificate for pulp and apache.