### PR TITLE
Switch to puppet/mongodb and correct puppet-extlib fixture

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,7 @@ fixtures:
     extlib:  "https://github.com/voxpupuli/puppet-extlib.git"
     apache:  "https://github.com/puppetlabs/puppetlabs-apache.git"
     concat:  "https://github.com/puppetlabs/puppetlabs-concat.git"
-    mongodb: "https://github.com/puppetlabs/puppetlabs-mongodb.git"
+    mongodb: "https://github.com/voxpupuli/puppet-mongodb.git"
     qpid:    "https://github.com/theforeman/puppet-qpid.git"
     squid3:  "https://github.com/thias/puppet-squid3.git"
   symlinks:

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   repositories:
     stdlib:  "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    extlib:  "https://github.com/puppet-community/puppet-extlib"
+    extlib:  "https://github.com/voxpupuli/puppet-extlib.git"
     apache:  "https://github.com/puppetlabs/puppetlabs-apache.git"
     concat:  "https://github.com/puppetlabs/puppetlabs-concat.git"
     mongodb: "https://github.com/puppetlabs/puppetlabs-mongodb.git"

--- a/metadata.json
+++ b/metadata.json
@@ -21,8 +21,8 @@
       "version_requirement": ">= 1.2.0 < 3.0.0"
     },
     {
-      "name": "puppetlabs/mongodb",
-      "version_requirement": ">= 0.10.0 < 2.0.0"
+      "name": "puppet/mongodb",
+      "version_requirement": ">= 1.1.0 < 2.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
The mongodb repository was transfered to voxpupuli and a 1.1.0 release was made.

puppet-community was renamed a long time ago, let's use the current name.