### PR TITLE
add hook for https vhost includes

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -114,6 +114,7 @@ class pulp::apache {
       add_default_charset        => 'UTF-8',
       # allow older yum clients to connect, see bz 647828
       custom_fragment            => 'SSLInsecureRenegotiation On',
+      additional_includes        => $::pulp::https_includes,
     }
 
     # This file is installed by pulp-server but we have everything in the above vhost

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,6 +104,8 @@
 #
 # $https_chain::                apache chain file for ssl
 #
+# $https_includes::             additional includes for https vhost
+#
 # $ssl_username::               Value to use for SSLUsername directive in apache vhost. Defaults to SSL_CLIENT_S_DN_CN.
 #                               Set an empty string or false to unset directive.
 #
@@ -294,6 +296,7 @@ class pulp (
   Optional[Stdlib::Absolutepath] $https_cert = $::pulp::params::https_cert,
   Optional[Stdlib::Absolutepath] $https_key = $::pulp::params::https_key,
   Optional[Stdlib::Absolutepath] $https_chain = $::pulp::params::https_chain,
+  Optional[Array] $https_includes = $::pulp::params::https_includes,
   Variant[String, Boolean] $ssl_username = $::pulp::params::ssl_username,
   Integer $user_cert_expiration = $::pulp::params::user_cert_expiration,
   Integer $consumer_cert_expiration = $::pulp::params::consumer_cert_expiration,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,6 +57,7 @@ class pulp::params {
   $https_cert = $ca_cert
   $https_key = $ca_key
   $https_chain = undef
+  $https_includes = undef
   $ssl_username = 'SSL_CLIENT_S_DN_CN'
   $enable_http = false
   $ssl_verify_client = 'require'


### PR DESCRIPTION
We have a need to provide additional configuration to our ssl vhost for pulp.  This provides a generic hook to specify includes to the vhost.