### PR TITLE
Fixes #21957 - Pulp-Ostree.conf handle gpg content

### DIFF
--- a/spec/classes/pulp_apache_spec.rb
+++ b/spec/classes/pulp_apache_spec.rb
@@ -348,6 +348,7 @@ Alias /pulp/python /var/www/pub/python/
 #
 RedirectMatch "^/pulp/ostree/web/(.*?)/repodata/(.*)"  "/pulp/repos/$1/repodata/$2"
 RedirectMatch "^/pulp/ostree/web/(.*?)\.rpm"  "/pulp/repos/$1.rpm"
+RedirectMatch "^/pulp/katello/api/repositories/(.*?)/gpg_key_content"  "/katello/api/repositories/$1/gpg_key_content"
 
 # -- HTTPS Repositories ---------
 

--- a/templates/etc/httpd/conf.d/pulp_ostree.conf.erb
+++ b/templates/etc/httpd/conf.d/pulp_ostree.conf.erb
@@ -3,6 +3,7 @@
 #
 RedirectMatch "^/pulp/ostree/web/(.*?)/repodata/(.*)"  "/pulp/repos/$1/repodata/$2"
 RedirectMatch "^/pulp/ostree/web/(.*?)\.rpm"  "/pulp/repos/$1.rpm"
+RedirectMatch "^/pulp/katello/api/repositories/(.*?)/gpg_key_content"  "/katello/api/repositories/$1/gpg_key_content"
 
 # -- HTTPS Repositories ---------
 


### PR DESCRIPTION
Added a Redirect rule to handle requests matching
/pulp/katello/api/repositories/(.*?)/gpg_key_content
The above URL is requested by an Atomic Host
during an rpm-ostree add/remove package operation.

Basically this needs to be redirected to
/katello/api/repositories/$1/gpg_key_content
instead.