### PR TITLE
Don't specify path to pulp-consumer

### DIFF
--- a/lib/puppet/provider/pulp_register/consumer.rb
+++ b/lib/puppet/provider/pulp_register/consumer.rb
@@ -1,7 +1,7 @@
 Puppet::Type.type(:pulp_register).provide(:consumer) do
   desc "Register/unregister a pulp consumer"
 
-  commands :consumer => '/bin/pulp-consumer'
+  commands :consumer => 'pulp-consumer'
   def exists?
     output = consumer('status')
     output.match(/This consumer is registered to the server/)

--- a/lib/puppet/provider/pulp_rpmbind/consumer.rb
+++ b/lib/puppet/provider/pulp_rpmbind/consumer.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:pulp_rpmbind).provide(:consumer) do
   desc 'Bind/unbind to an RPM repo'
 
   confine osfamily: :redhat
-  commands consumer: '/bin/pulp-consumer'
+  commands consumer: 'pulp-consumer'
   commands grep:     '/bin/grep'
 
   def self.repo_file


### PR DESCRIPTION
Specifying the path isn't necessary.
From http://garylarizza.com/blog/2013/11/26/fun-with-providers-part-2/

> We don’t REQUIRE you to pass the full path because sometimes the same
> binary exists in different locations for different operatingsystems.
> Instead of creating a provider for each OS you manage with Puppet, we
> abstract away the path stuff. You CAN still pass a full path as a
> value, but if you elect to do that an the binary doesn’t exist at that
> path, Puppet will disqualify the provider and you’ll be quite upset.

With this simple change I was able to use pulp::consumer on a CentOS 6
system.