### PR TITLE
Allow the setting of vhost in consumer messaging section.

### DIFF
--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -76,6 +76,8 @@
 #
 # $messaging_transport::           The AMQP transport name. Valid options are 'qpid' or 'rabbitmq'. The default is 'qpid'.
 #
+# $messaging_vhost::               The (optional) broker vhost. This is only valid when using 'rabbitmq' as the messaging_transport.
+#
 # $messaging_version::             Determines the version of packages related to the 'messaging transport protocol'.
 #
 # $messaging_cacert::              The (optional) absolute path to a PEM encoded CA certificate to validate the identity of the
@@ -123,6 +125,7 @@ class pulp::consumer (
   String $messaging_host = $::pulp::consumer::params::messaging_host,
   Integer[0, 65535] $messaging_port = $::pulp::consumer::params::messaging_port,
   String $messaging_transport = $::pulp::consumer::params::messaging_transport,
+  Optional[String] $messaging_vhost = $::pulp::consumer::params::messaging_vhost,
   String $messaging_version = $::pulp::consumer::params::messaging_version,
   Optional[Stdlib::Absolutepath] $messaging_cacert = $::pulp::consumer::params::messaging_cacert,
   Optional[Stdlib::Absolutepath] $messaging_clientcert = $::pulp::consumer::params::messaging_clientcert,

--- a/manifests/consumer/params.pp
+++ b/manifests/consumer/params.pp
@@ -40,6 +40,7 @@ class pulp::consumer::params {
   $messaging_host = $host
   $messaging_port = 5672
   $messaging_transport = 'qpid'
+  $messaging_vhost = undef
   $messaging_cacert = undef
   $messaging_clientcert = undef
   $messaging_version = 'present'

--- a/spec/classes/pulp_consumer_spec.rb
+++ b/spec/classes/pulp_consumer_spec.rb
@@ -151,7 +151,7 @@ describe 'pulp::consumer' do
           'messaging_vhost' => 'pulp',
         } end
 
-      it 'should set consumer.conf file' do
+      it 'should set vhost in the consumer.conf file' do
         should contain_file('/etc/pulp/consumer/consumer.conf').
           with_content(/^\[messaging\]$/).
           with_content(/^vhost: pulp$/).

--- a/spec/classes/pulp_consumer_spec.rb
+++ b/spec/classes/pulp_consumer_spec.rb
@@ -146,6 +146,19 @@ describe 'pulp::consumer' do
       end
     end
 
+    context 'install with messaging_vhost param' do
+      let(:params) do {
+          'messaging_vhost' => 'pulp',
+        } end
+
+      it 'should set consumer.conf file' do
+        should contain_file('/etc/pulp/consumer/consumer.conf').
+          with_content(/^\[messaging\]$/).
+          with_content(/^vhost: pulp$/).
+          with_ensure('file')
+      end
+    end
+
     context 'install with params' do
       let(:params) do {
           'host' => 'pulp.company.net',

--- a/spec/classes/pulp_consumer_spec.rb
+++ b/spec/classes/pulp_consumer_spec.rb
@@ -55,6 +55,7 @@ describe 'pulp::consumer' do
           with_content(/^host: foo.example.com$/).
           with_content(/^port: 5672$/).
           with_content(/^transport: qpid$/).
+          without_content(/^vhost:/).
           with_content(/^\[profile\]$/).
           with_content(/^minutes: 240$/).
           with_ensure('file')

--- a/templates/consumer.conf.erb
+++ b/templates/consumer.conf.erb
@@ -154,6 +154,9 @@ scheme: <%= scope['pulp::consumer::messaging_scheme'] %>
 host: <%= scope['pulp::consumer::messaging_host'] %>
 port: <%= scope['pulp::consumer::messaging_port'] %>
 transport: <%= scope['pulp::consumer::messaging_transport'] %>
+<% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar('pulp::consumer::messaging_vhost')) -%>
+vhost: <%= scope['pulp::consumer::messaging_vhost'] %>
+<% end -%>
 <% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar('pulp::consumer::messaging_cacert')) -%>
 cacert: <%= scope['pulp::consumer::messaging_cacert'] %>
 <% end -%>


### PR DESCRIPTION
When using rabbitmq as a messaging transport for consumer, we should be able to set a vhost. vhost is a valid parameter since 2.8.