### PR TITLE
Fixes #23233 - updated yum_max_speed example to reflect to_bytes parsing

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -186,7 +186,7 @@
 #
 # $proxy_password::             Proxy password for authentication
 #
-# $yum_max_speed::              The maximum download speed for a Pulp task, such as a sync. (e.g. "4 Kb" or 1Gb")
+# $yum_max_speed::              The maximum download speed for a Pulp task, such as a sync. (e.g. "4 kb" or "1 Gb")
 #
 # $yum_gpg_sign_repo_metadata:: Whether yum repo metadata GPG signing will be enabled
 #


### PR DESCRIPTION
Updated the init.pp description too since passing Kb fails with an error, as its the to bytes conversion is not happy with uppercase.