### PR TITLE
Fix wait_for_bind grep being poorly escaped

### DIFF
--- a/lib/puppet/provider/pulp_rpmbind/consumer.rb
+++ b/lib/puppet/provider/pulp_rpmbind/consumer.rb
@@ -59,7 +59,7 @@ Puppet::Type.type(:pulp_rpmbind).provide(:consumer) do
 
   def wait_for_bind
     tries ||= 10
-    grep('-q', "^\\[#{@resource[:name]}\\]$", self.class.repo_file)
+    grep('-q', '--fixed-strings', "[#{@resource[:name]}]", self.class.repo_file)
   rescue Puppet::ExecutionFailure
     raise "Pulp bind to #{@resource[:name]} failed" unless (tries -= 1) > 0
     Puppet.debug("Waiting for pulp rpm bind to #{@resource[:name]} to take place")

--- a/spec/unit/puppet/provider/pulp_rpmbind/consumer_spec.rb
+++ b/spec/unit/puppet/provider/pulp_rpmbind/consumer_spec.rb
@@ -56,14 +56,14 @@ describe provider_class do
         context 'bind works first time' do
           it 'doesn\'t raise exception' do
             provider.expects(:grep)
-                    .with('-q', '^\[foo\]$', '/etc/yum.repos.d/pulp.repo')
+                    .with('-q', '--fixed-strings', '[foo]', '/etc/yum.repos.d/pulp.repo')
             expect { provider.wait_for_bind }.not_to raise_error
           end
         end
         context 'bind works after 2 retries' do
           it 'sleeps between retries and then succeeds' do
             provider.expects(:grep).times(3)
-                    .with('-q', '^\[foo\]$', '/etc/yum.repos.d/pulp.repo')
+                    .with('-q', '--fixed-strings', '[foo]', '/etc/yum.repos.d/pulp.repo')
                     .raises(Puppet::ExecutionFailure, '')
                     .raises(Puppet::ExecutionFailure, '')
                     .then.returns('')
@@ -74,7 +74,7 @@ describe provider_class do
         context 'bind doesn\'t complete after 10 retries' do
           it 'tries 10 times then raises exception' do
             provider.expects(:grep).times(10)
-                    .with('-q', '^\[foo\]$', '/etc/yum.repos.d/pulp.repo')
+                    .with('-q', '--fixed-strings', '[foo]', '/etc/yum.repos.d/pulp.repo')
                     .raises(Puppet::ExecutionFailure, '')
             expect { provider.wait_for_bind }
               .to raise_error(RuntimeError, 'Pulp bind to foo failed')


### PR DESCRIPTION
The grep wasn't properly escaped.
I have a pulp repo named 'centos-7.5.1804-x86_64-base'

The grep in wait_for_bind was failing with
```
/bin/grep: Invalid range end
```

Using `--fixed-strings` is a lot safer than trying to figure out what
characters in a repo name might need to be escaped.