### PR TITLE
Generate/regenerate Yum repository metadata GPG signatures

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -283,6 +283,9 @@
 # @param yum_gpg_cmd
 #   Custom GPG command/script to use for yum repo metadata signing
 #
+# @param yum_regenerate_repomd_signatures
+#   Whether to regenerate existing yum repo metadata GPG signatures
+#
 # @param num_workers
 #   Number of Pulp workers to use.
 #
@@ -487,6 +490,7 @@ class pulp (
   Boolean $yum_gpg_sign_repo_metadata = $pulp::params::yum_gpg_sign_repo_metadata,
   Optional[String] $yum_gpg_key_id = $pulp::params::yum_gpg_key_id,
   Optional[String] $yum_gpg_cmd = $pulp::params::yum_gpg_cmd,
+  Boolean $yum_regenerate_repomd_signatures = $pulp::params::yum_regenerate_repomd_signatures,
   Integer[0] $num_workers = $pulp::params::num_workers,
   Integer[0] $worker_timeout = $pulp::params::worker_timeout,
   Boolean $enable_admin = $pulp::params::enable_admin,
@@ -567,6 +571,10 @@ class pulp (
 
   Class['pulp::install'] -> Class['pulp::config'] -> Class['pulp::database'] ~> Class['pulp::service', 'pulp::apache']
   Class['pulp::config'] ~> Class['pulp::service', 'pulp::apache']
+
+  if $yum_gpg_sign_repo_metadata {
+    contain ::pulp::repomd_signatures
+  }
 
   if $enable_admin {
     if $ssl_username and $ssl_username != '' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -123,6 +123,7 @@ class pulp::params {
   $yum_gpg_sign_repo_metadata = false
   $yum_gpg_key_id = undef
   $yum_gpg_cmd = undef
+  $yum_regenerate_repomd_signatures = false
 
   $wsgi_processes = 3
   $wsgi_max_requests = 0

--- a/manifests/repomd_signatures.pp
+++ b/manifests/repomd_signatures.pp
@@ -1,0 +1,35 @@
+# Generate or regenerate Yum repository metadata GPG signatures
+class pulp::repomd_signatures {
+  # gpg requires $HOME to be set properly, but puppet 'exec' only supports hard-
+  # coding $HOME via the 'environment' parameter (it cannot read it from
+  # /etc/passwd).  To work around this, use `sudo -H` to read /etc/passwd and
+  # set $HOME properly.
+  $shell = "/usr/bin/sudo -u apache -H /usr/bin/bash -c '"
+  $set = '
+    set -e'
+  $loop = '
+    cd /var/lib/pulp/published/yum/master/yum_distributor/ 2>/dev/null || exit 0
+    for d1 in * ; do (
+      cd $d1
+      for d2 in * ; do (
+        cd $d2/repomd
+  '
+  $test = '[ -e repomd.xml.asc ] || '
+  $gen_sig = 'gpg --yes --detach-sign --armor repomd.xml'
+  $stop = 'exit 1'
+  $end = "
+      ) ; done
+    ) ; done
+  '"
+
+  if $::pulp::yum_regenerate_repomd_signatures {
+    exec { 'yum_generate_repomd_signatures':
+      command => "${shell}${loop}${gen_sig}${end}",
+    }
+  } else {
+    exec { 'yum_generate_repomd_signatures':
+      unless  => "${shell}${set}${loop}${test}${stop}${end}",
+      command => "${shell}${loop}${test}${gen_sig}${end}",
+    }
+  }
+}


### PR DESCRIPTION
This is related to https://github.com/theforeman/puppet-certs/pull/188

If a yum repomd GPG key is configured on an existing Pulp server that already has published repositories, then repomd signatures will need to be generated for those existing repositories.