### PR TITLE
allow to change http/https port

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -14,7 +14,7 @@ class pulp::apache {
       apache::vhost { 'pulp-http':
         priority            => '05',
         docroot             => '/usr/share/pulp/wsgi',
-        port                => 80,
+        port                => $::pulp::http_port,
         servername          => $::fqdn,
         serveraliases       => [$::hostname],
         additional_includes => '/etc/pulp/vhosts80/*.conf',
@@ -73,7 +73,7 @@ class pulp::apache {
     apache::vhost { 'pulp-https':
       priority                   => '05',
       docroot                    => '/usr/share/pulp/wsgi',
-      port                       => 443,
+      port                       => $::pulp::https_port,
       servername                 => $::fqdn,
       serveraliases              => [$::hostname],
       keepalive                  => 'on',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -219,6 +219,10 @@
 #
 # $enable_http::                Whether to enable http access to deb/rpm repos.
 #
+# $http_port::                  HTTP port Apache will listen
+#
+# $https_port::                 HTTPS port Apache will listen
+#
 # $manage_httpd::               Whether to install and configure the httpd server.
 #
 # $manage_plugins_httpd::       Whether to install the enabled pulp plugins apache configs even if $manage_httpd is

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -327,6 +327,8 @@ class pulp (
   Optional[String] $tasks_login_method = $::pulp::params::tasks_login_method,
   String $email_host = $::pulp::params::email_host,
   Integer[1, 65535] $email_port = $::pulp::params::email_port,
+  Integer[1, 65535] $http_port = $::pulp::params::http_port,
+  Integer[1, 65535] $https_port = $::pulp::params::https_port,
   String $email_from = $::pulp::params::email_from,
   Boolean $email_enabled = $::pulp::params::email_enabled,
   Boolean $manage_squid = $::pulp::params::manage_squid,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,6 +59,8 @@ class pulp::params {
   $https_chain = undef
   $ssl_username = 'SSL_CLIENT_S_DN_CN'
   $enable_http = false
+  $http_port = 80
+  $https_port = 443
   $ssl_verify_client = 'require'
   $ssl_protocol = ['all', '-SSLv2', '-SSLv3']
 


### PR DESCRIPTION
Please, allow to change Apache ports through this tiny change. 
In my case I'd like to use Pulp on the same server where I'm already running Nginx, and I'm not willing to configure UWSGI on Nginx.