### PR TITLE
Fixes #22746 - Switch to voxpupuli/squid

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,7 +6,7 @@ fixtures:
     concat:  "https://github.com/puppetlabs/puppetlabs-concat.git"
     mongodb: "https://github.com/voxpupuli/puppet-mongodb.git"
     qpid:    "https://github.com/theforeman/puppet-qpid.git"
-    squid3:  "https://github.com/thias/puppet-squid3.git"
+    squid:   "https://github.com/voxpupuli/puppet-squid.git"
     systemd: 'https://github.com/camptocamp/puppet-systemd.git'
     yumrepo_core:
       repo: "https://github.com/puppetlabs/puppetlabs-yumrepo_core"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -145,23 +145,7 @@ class pulp::config {
   }
 
   if $pulp::manage_squid {
-    class { 'squid3':
-      use_deprecated_opts           => false,
-      http_port                     => [ '3128 accel defaultsite=127.0.0.1:8751' ],
-      acl                           => [ 'Safe_ports port 3128' ],
-      http_access                   => [ 'allow localhost', 'deny to_localhost', 'deny all' ],
-      cache                         => [ 'allow all' ],
-      maximum_object_size           => '5 GB',
-      maximum_object_size_in_memory => '100 MB',
-      cache_dir                     => [ 'aufs /var/spool/squid 10000 16 256' ],
-      template                      => 'short',
-      config_hash                   => {
-        cache_peer          => '127.0.0.1 parent 8751 0 no-digest no-query originserver name=PulpStreamer',
-        cache_peer_access   => 'PulpStreamer allow all',
-        range_offset_limit  => 'none',
-        minimum_object_size => '0 kB',
-      },
-    }
+    contain pulp::squid
   }
 
   if $pulp::enable_profiling {

--- a/manifests/squid.pp
+++ b/manifests/squid.pp
@@ -1,0 +1,55 @@
+# The class to manage squid. This is used by pulp streamer.
+class pulp::squid(
+  Stdlib::Port $port = 3128,
+  Stdlib::Host $streamer_host = '127.0.0.1',
+  Stdlib::Port $streamer_port = 8751,
+  String $maximum_object_size = '5 GB',
+  String $maximum_object_size_in_memory = '100 MB',
+  Stdlib::Absolutepath $cache_dir = '/var/spool/squid',
+) {
+  class { 'squid':
+    maximum_object_size_in_memory => $maximum_object_size_in_memory,
+  }
+
+  squid::acl { 'Safe_ports':
+    type    => 'port',
+    entries => [$port],
+  }
+
+  squid::http_port { 'pulp internal port':
+    port    => $port,
+    options => "accel defaultsite=${streamer_host}:${streamer_port}",
+  }
+
+  squid::http_access { 'localhost':
+    action => 'allow',
+  }
+
+  squid::http_access { 'to_localhost':
+    action => 'deny',
+  }
+
+  squid::http_access { 'all':
+    action => 'deny',
+  }
+
+  squid::cache { 'all':
+    action => 'allow',
+  }
+
+  squid::cache_dir { $cache_dir:
+    type    => 'aufs',
+    options => '10000 16 256',
+  }
+
+  squid::extra_config_section { 'extra settings':
+    order          => '60',
+    config_entries => {
+      'cache_peer'          => "${streamer_host} parent ${streamer_port} 0 no-digest no-query originserver name=PulpStreamer",
+      'cache_peer_access'   => 'PulpStreamer allow all',
+      'range_offset_limit'  => 'none',
+      'maximum_object_size' => $maximum_object_size,
+      'minimum_object_size' => '0 kB',
+    },
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -33,8 +33,8 @@
       "version_requirement": ">= 2.0.0 < 5.0.0"
     },
     {
-      "name": "thias/squid3",
-      "version_requirement": "1.0.2"
+      "name": "puppet/squid",
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "requirements": [

--- a/spec/acceptance/pulp_squid_spec.rb
+++ b/spec/acceptance/pulp_squid_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper_acceptance'
+
+describe 'squid' do
+  let(:pp) { 'include pulp::squid' }
+
+  it_behaves_like 'a idempotent resource'
+
+  describe service('squid') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe port(3128) do
+    it { is_expected.to be_listening }
+  end
+
+  describe port(8751) do
+    it { is_expected.to be_listening.on('127.0.0.1') }
+  end
+end

--- a/spec/classes/pulp_squid_spec.rb
+++ b/spec/classes/pulp_squid_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'pulp::squid' do
+  on_supported_os.each do |os, facts|
+    let(:facts) { facts }
+
+    describe "on #{os}" do
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('squid').with_maximum_object_size_in_memory('100 MB') }
+      it { is_expected.to contain_squid__acl('Safe_ports').with_type('port').with_entries([3128]) }
+      it { is_expected.to contain_squid__http_port('pulp internal port').with_port(3128).with_options('accel defaultsite=127.0.0.1:8751') }
+      it { is_expected.to contain_squid__http_access('localhost').with_action('allow') }
+      it { is_expected.to contain_squid__http_access('to_localhost').with_action('deny') }
+      it { is_expected.to contain_squid__http_access('all').with_action('deny') }
+      it { is_expected.to contain_squid__cache('all').with_action('allow') }
+      it { is_expected.to contain_squid__cache_dir('/var/spool/squid') }
+    end
+  end
+end


### PR DESCRIPTION
The module thias/squid3 is unmaintained so we're switching to a maintained module. We also take the chance to make it possible to override some parameters.