### PR TITLE
Massively speed up providers and fix timeouts

### DIFF
--- a/lib/puppet/util/pulp_util.rb
+++ b/lib/puppet/util/pulp_util.rb
@@ -47,7 +47,7 @@ module Puppet
 
       def get_repo_info(repo_id)
         raise '[get_repo_info] Repo id should never be nil.' unless repo_id and repo_id != ''
-        request_api("/v2/repositories/#{repo_id}/?details=True")
+        request_api("/v2/repositories/#{repo_id}/?distributors=True&importers=True")
       end
 
       def get_role_info(role_id)


### PR DESCRIPTION
In my environment, `get_repo_info` was failing with...

```
Error: Failed to apply catalog: https request threw exception Net::ReadTimeout. Connection details: url=https://pulp.example.com/pulp/api/v2/repositories/oel-6-x86_64-latest/?details=True,cert_path=/root/.pulp/user-cert.pem.
```

`details=True` can be *very* slow.  It causes huge amounts of processing
and we don't use the results.  Using `?distributors=True&importers=True`
instead is *much* faster.

I've got repos where `?distributors=True&importers=True` returns in around
a second whilst `details=True` took > 4 minutes (testing the REST API
manually with curl).

The returned json (for an RPM repo) is missing just 2 fields compared to
`details=True`.  These are:

* `locally_stored_units`
* `total_repository_units`

See
https://docs.pulpproject.org/dev-guide/integration/rest-api/repo/retrieval.html#retrieve-a-single-repository

This change has been tested with `pulp_rpmrepo` only, but I think should
also be fine with the two other providers (`pulp_isorepo` and
`pulp_puppetrepo`).

My puppet runs had started failing most times, and sucessful runs were
taking around 10 minutes.  After this fix, puppet runs are now less than
a minute.