### PR TITLE
Remove redundant symlink

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,5 +8,3 @@ fixtures:
     qpid:    "https://github.com/theforeman/puppet-qpid.git"
     squid3:  "https://github.com/thias/puppet-squid3.git"
     systemd: 'https://github.com/camptocamp/puppet-systemd.git'
-  symlinks:
-    pulp: "#{source_dir}"


### PR DESCRIPTION
With recent versions of puppetlabs_spec_helper this is done automatically