### PR TITLE
Add remove_missing to pulp_deb

### DIFF
--- a/templates/deb_importer.json.erb
+++ b/templates/deb_importer.json.erb
@@ -1,4 +1,5 @@
 {
+    "remove_missing": true,
     <% unless [nil, :undefined, :undef, ''].include?(scope['pulp::proxy_url']) -%>
     "proxy_host": "<%= scope['pulp::proxy_url'] %>",
     <% else %>


### PR DESCRIPTION
We want to default to mirroring mode in debian.