### PR TITLE
Add `scheduled_repo` wrapper defined type

### DIFF
--- a/functions/daily_schedule.pp
+++ b/functions/daily_schedule.pp
@@ -1,0 +1,10 @@
+# @api private
+# @param seed A seed to pass to `fqdn_rand`.  A good choice is the repo name that this schedule will be for.
+# @return Returns a 'pseudo-random' daily iso8601 schedule.
+# @example Calling the function
+#    pulp::daily_schedule('centos-7')
+function pulp::daily_schedule(String $seed) >> String {
+  $random_hour   = sprintf('%02d', fqdn_rand(23, $seed))
+  $random_minute = sprintf('%02d', fqdn_rand(59, $seed))
+  "2000-01-01T${random_hour}:${random_minute}Z/P1D"
+}

--- a/manifests/scheduled_repo.pp
+++ b/manifests/scheduled_repo.pp
@@ -1,0 +1,36 @@
+# @summary A wrapper that creates a pulp_Xrepo resource with and an associated pulp_schedule resource
+#
+# @example Basic usage with default `rpm` `repo_type` and 'random' daily schedule
+#   pulp::scheduled_repo { 'centos-7':
+#     repo_config => {
+#       'display_name' => 'CentOS 7 Base Repo',
+#       'feed'         => 'https://www.mirrorservice.org/sites/mirror.centos.org/7/os/x86_64',
+#     },
+#   }
+#
+# @param repo_type
+#   Determines whether a `pulp_rpmrepo`, `pulp_puppetrepo` or `pulp_isorepo` resource is created.
+# @param repo_config
+#   Defines a hash of parameters to pass to the `pulp_Xrepo` resource.
+# @param repo_schedule
+#   An iso8601 schedule string or the special value 'daily'. Defaults to 'daily' which creates a `pulp_schedule` with a pseudo-random daily `schedule_time`.
+define pulp::scheduled_repo
+(
+  Enum['rpm','puppet','iso'] $repo_type = 'rpm',
+  Hash $repo_config = {},
+  Variant[Enum['daily'],Pulp::Iso8601TimeInterval] $repo_schedule = 'daily',
+)
+{
+  $schedule_time = $repo_schedule ? {
+    'daily' => pulp::daily_schedule($name),
+    default => $repo_schedule,
+  }
+
+  Resource["pulp_${repo_type}repo"] { $name:
+    * => $repo_config,
+  }
+
+  pulp_schedule { $name:
+    schedule_time => $schedule_time,
+  }
+}

--- a/spec/defines/pulp_scheduled_repo_spec.rb
+++ b/spec/defines/pulp_scheduled_repo_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+describe 'pulp::scheduled_repo' do
+  let :facts do
+    on_supported_os['redhat-7-x86_64']
+  end
+
+  let :title do
+    'centos-7'
+  end
+
+  context 'with default parameters' do
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to have_pulp_rpmrepo_resource_count(1) }
+    it { is_expected.to have_pulp_schedule_resource_count(1) }
+    it { is_expected.to contain_pulp_rpmrepo('centos-7') }
+    it { is_expected.to contain_pulp_schedule('centos-7').with_schedule_time('2000-01-01T22:38Z/P1D') }
+  end
+
+  context 'when repo_type is \'puppet\'' do
+    let :params do
+      {
+        repo_type: 'puppet'
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to have_pulp_rpmrepo_resource_count(0) }
+    it { is_expected.to have_pulp_puppetrepo_resource_count(1) }
+    it { is_expected.to contain_pulp_puppetrepo('centos-7') }
+  end
+
+  context 'when repo_type is \'iso\'' do
+    let :params do
+      {
+        repo_type: 'iso'
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to have_pulp_rpmrepo_resource_count(0) }
+    it { is_expected.to have_pulp_isorepo_resource_count(1) }
+    it { is_expected.to contain_pulp_isorepo('centos-7') }
+  end
+
+  context 'with custom schedule' do
+    let :params do
+      {
+        repo_schedule: '2019-01-01T00:42Z/P1D'
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_pulp_schedule('centos-7').with_schedule_time('2019-01-01T00:42Z/P1D') }
+  end
+
+  context 'with valid repo_config set' do
+    let :params do
+      {
+        repo_config: {
+          'display_name' => 'CentOS 7 Base Repo',
+          'feed' => 'https://www.mirrorservice.org/sites/mirror.centos.org/7/os/x86_64'
+        }
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it {
+      is_expected.to contain_pulp_rpmrepo('centos-7').with(
+        'display_name' => 'CentOS 7 Base Repo',
+        'feed' => 'https://www.mirrorservice.org/sites/mirror.centos.org/7/os/x86_64'
+      )
+    }
+  end
+
+  context 'with invalid repo_config set' do
+    let :params do
+      {
+        repo_config: {
+          'no_such_parameter' => 'foo'
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(/no parameter named 'no_such_parameter'/) }
+  end
+end

--- a/types/iso8601timeinterval.pp
+++ b/types/iso8601timeinterval.pp
@@ -1,0 +1,3 @@
+# https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
+# TODO: Actually implement a regex.
+type Pulp::Iso8601TimeInterval = String[1]


### PR DESCRIPTION
I never create an `pulp_rpmrepo` without also creating a `pulp_schedule`.  This wrapper provides a convenient shortcut.