### PR TITLE
Fixes #26323 - Remove max_tasks_per_child setting

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -200,9 +200,6 @@
 #
 # $enable_crane::               Whether to enable crane docker repository
 #
-# $max_tasks_per_child::        Number of tasks after which the worker is restarted and the memory it allocated is
-#                               returned to the system
-#
 # $enable_rpm::                 Whether to enable rpm plugin.
 #
 # $enable_deb::                 Whether to enable deb plugin.
@@ -360,7 +357,6 @@ class pulp (
   Boolean $enable_admin = $pulp::params::enable_admin,
   Boolean $enable_katello = $pulp::params::enable_katello,
   Boolean $enable_crane = $pulp::params::enable_crane,
-  Optional[Integer[0]] $max_tasks_per_child = $pulp::params::max_tasks_per_child,
   Boolean $enable_deb = $pulp::params::enable_deb,
   Boolean $enable_docker = $pulp::params::enable_docker,
   Boolean $enable_rpm = $pulp::params::enable_rpm,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -116,7 +116,6 @@ class pulp::params {
 
   $max_keep_alive = 10000
   $num_workers = min($facts['processorcount'], 8)
-  $max_tasks_per_child = undef
   $worker_timeout = 30
 
   $yum_max_speed = undef

--- a/templates/systemd_pulp_workers
+++ b/templates/systemd_pulp_workers
@@ -6,11 +6,3 @@ PULP_CONCURRENCY=<%= scope['pulp::num_workers'] %>
 
 # Configure Python's encoding for writing all logs, stdout and stderr
 PYTHONIOENCODING="UTF-8"
-
-# To avoid memory leaks, Pulp can terminate and replace a worker after processing X tasks. If
-# left commented, process recycling is disabled. PULP_MAX_TASKS_PER_CHILD must be > 0.
-<% unless [nil, :undefined, :undef, '', 0].include?(scope.lookupvar('pulp::max_tasks_per_child')) %>
-PULP_MAX_TASKS_PER_CHILD=<%= scope['pulp::max_tasks_per_child'] %>
-<% else %>
-# PULP_MAX_TASKS_PER_CHILD=2
-<% end %>


### PR DESCRIPTION
Will open up Refs prs to the other modules that have this setting including katello-devel so they can be merged after this one is accepted.