### PR TITLE
Convert documentation to yardoc

### DIFF
--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -1,77 +1,106 @@
-#
-# == Class: pulp::admin
-#
 # Install and configure Pulp admin
 #
-# === Parameters:
+# @param version
+#   Pulp admin package version, it's passed to ensure parameter of package
+#   resource can be set to specific version number, 'latest', 'present' etc.
 #
-# $version::                       pulp admin package version, it's passed to ensure parameter of package resource
-#                                  can be set to specific version number, 'latest', 'present' etc.
+# @param host
+#   The pulp server hostname
 #
-# $host::                          The pulp server hostname
+# @param port
+#   The port providing the RESTful API
 #
-# $port::                          The port providing the RESTful API
+# @param api_prefix
+#   The REST API prefix.
 #
-# $api_prefix::                    The REST API prefix.
+# @param verify_ssl
+#   Set this to False to configure the client not to verify that the server's
+#   SSL cert is signed by a trusted authority
 #
-# $verify_ssl::                    Set this to False to configure the client not to verify that the server's SSL cert is signed by
-#                                  a trusted authority
+# @param ca_path
+#   This is a path to a file of concatenated trusted CA certificates, or to a
+#   directory of trusted CA certificates (with openssl-style hashed symlinks,
+#   one certificate per file).
 #
-# $ca_path::                       This is a path to a file of concatenated trusted CA certificates, or to a directory of trusted
-#                                  CA certificates (with openssl-style hashed symlinks, one certificate per file).
+# @param upload_chunk_size
+#   upload_chunk_size
 #
-# $upload_chunk_size::             upload_chunk_size
+# @param role
+#   The client role.
 #
-# $role::                          The client role.
+# @param extensions_dir
+#   The location of admin client extensions.
 #
-# $extensions_dir::                The location of admin client extensions.
+# @param id_cert_dir
+#   The location of the directory where the Pulp user ID certificate is stored.
 #
-# $id_cert_dir::                   The location of the directory where the Pulp user ID certificate is stored.
+# @param id_cert_filename
+#   The name of the file containing the PEM encoded client private key and
+#   X.509 certificate. This file is downloaded and stored here during login.
 #
-# $id_cert_filename::              The name of the file containing the PEM encoded client private key and X.509
-#                                  certificate. This file is downloaded and stored here during login.
+# @param upload_working_dir
+#   Directory where status files for in progress uploads will be stored
 #
-# $upload_working_dir::            Directory where status files for in progress uploads will be stored
+# @param log_filename
+#   The location of the admin client log file.
 #
-# $log_filename::                  The location of the admin client log file.
+# @param call_log_filename
+#   If present, the raw REST responses will be logged to the given file.
 #
-# $call_log_filename::             If present, the raw REST responses will be logged to the given file.
+# @param poll_frequency_in_seconds
+#   Number of seconds between requests for any operation that repeatedly polls
+#   the server for data.
 #
-# $poll_frequency_in_seconds::     Number of seconds between requests for any operation that repeatedly polls
-#                                  the server for data.
+# @param enable_color
+#   Set this to false to disable all color escape sequences
 #
-# $enable_color::                  Set this to false to disable all color escape sequences
+# @param wrap_to_terminal
+#   If wrap_to_terminal is true, any text wrapping will use the current width
+#   of the terminal. If false, the value in wrap_width is used.
 #
-# $wrap_to_terminal::              If wrap_to_terminal is true, any text wrapping will use the current width of
-#                                  the terminal. If false, the value in wrap_width is used.
+# @param wrap_width
+#   The number of characters written before wrapping to the next line.
 #
-# $wrap_width::                    The number of characters written before wrapping to the next line.
+# @param enable_puppet
+#   Install puppet extension. Defaults to false.
 #
-# $enable_puppet::                 Install puppet extension. Defaults to false.
+# @param enable_deb
+#   Install deb extension. Defaults to false.
 #
-# $enable_deb::                    Install deb extension. Defaults to false.
+# @param enable_docker
+#   Install docker extension. Defaults to false.
 #
-# $enable_docker::                 Install docker extension. Defaults to false.
+# @param enable_nodes
+#   Install nodes extension. Defaults to false.
 #
-# $enable_nodes::                  Install nodes extension. Defaults to false.
+# @param enable_python
+#   Install python extension. Defaults to false.
 #
-# $enable_python::                 Install python extension. Defaults to false.
+# @param enable_ostree
+#   Install ostree extension. Defaults to false.
 #
-# $enable_ostree::                 Install ostree extension. Defaults to false.
+# @param enable_rpm
+#   Install rpm extension. Defaults to true.
 #
-# $enable_rpm::                    Install rpm extension. Defaults to true.
+# @param enable_iso
+#   Install ISO extension. Defaults to true.
 #
-# $enable_iso::                    Install ISO extension. Defaults to true.
+# @param puppet_upload_working_dir
+#   Directory where status files for in progress uploads will be stored
 #
-# $puppet_upload_working_dir::     Directory where status files for in progress uploads will be stored
+# @param puppet_upload_chunk_size
+#   Maximum amount of data (in bytes) sent for an upload in a single request
 #
-# $puppet_upload_chunk_size::      Maximum amount of data (in bytes) sent for an upload in a single request
+# @param login_method
+#   The method to ensure root can use pulp-admin. Choose none to disable this
+#   behaviour.
 #
-# $login_method::                  The method to ensure root can use pulp-admin. Choose none to disable this behaviour.
+# @param username
+#   The username to login with
 #
-# $username::                      The username to login with
-#
-# $password::                      The password to login with. If left undefined then no login will be performed.
+# @param password
+#   The password to login with. If left undefined then no login will be
+#   performed.
 #
 class pulp::admin (
   String $version = $pulp::admin::params::version,

--- a/manifests/admin/config.pp
+++ b/manifests/admin/config.pp
@@ -1,4 +1,5 @@
 # Pulp Admin Configuration
+# @api private
 class pulp::admin::config {
   file { '/etc/pulp/admin/admin.conf':
     ensure  => 'file',

--- a/manifests/admin/install.pp
+++ b/manifests/admin/install.pp
@@ -1,4 +1,5 @@
 # Pulp Admin Install Packages
+# @api private
 class pulp::admin::install {
   package { 'pulp-admin-client':
     ensure => $pulp::admin::version,

--- a/manifests/admin/login.pp
+++ b/manifests/admin/login.pp
@@ -1,3 +1,5 @@
+# Ensure the user is logged in to execute commands
+# @api private
 class pulp::admin::login (
   $login_method = $pulp::admin::login_method,
   $username = $pulp::admin::username,

--- a/manifests/admin/params.pp
+++ b/manifests/admin/params.pp
@@ -1,4 +1,5 @@
 # Pulp Admin Params
+# @api private
 class pulp::admin::params {
   $version            = 'installed'
   $host               = $facts['fqdn']

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -1,4 +1,5 @@
 # configure apache
+# @api private
 class pulp::apache {
   include apache
   include apache::mod::proxy

--- a/manifests/apache/fragment.pp
+++ b/manifests/apache/fragment.pp
@@ -1,11 +1,11 @@
-# provides the ability to specify fragments for the ssl
-#   virtual host defined for a Pulp server
+# Provides the ability to specify fragments for the ssl virtual host defined
+# for a Pulp server
 #
-#  === Parameters:
+# @param ssl_content
+#   Content of the ssl virtual host fragment
 #
-#  $ssl_content:: content of the ssl virtual host fragment
-#
-#  $order:: the order in which to load the concat fragments
+# @param order
+#   The order in which to load the concat fragments
 #
 define pulp::apache::fragment(
   String $ssl_content,

--- a/manifests/apache_plugin.pp
+++ b/manifests/apache_plugin.pp
@@ -1,3 +1,5 @@
+# Define a the Apache config for a plugin
+# @api private
 define pulp::apache_plugin ($confd = true, $vhosts80 = true) {
   include apache
 

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -1,4 +1,5 @@
 # Set up the broker
+# @api private
 class pulp::broker {
   if $pulp::messaging_transport == 'qpid' {
     $broker_service = 'qpidd'

--- a/manifests/child.pp
+++ b/manifests/child.pp
@@ -1,6 +1,3 @@
-#
-# == Class: pulp::child
-#
 # Install and configure Pulp node
 #
 class pulp::child (

--- a/manifests/child/apache.pp
+++ b/manifests/child/apache.pp
@@ -1,3 +1,5 @@
+# Define an Apache config for a Pulp node deployment
+# @api private
 class pulp::child::apache (
   $servername = $facts['fqdn'],
   $ssl_cert = $pulp::child::ssl_cert,

--- a/manifests/child/config.pp
+++ b/manifests/child/config.pp
@@ -1,4 +1,5 @@
 # Pulp Node Configuration
+# @api private
 class pulp::child::config(
   $node_certificate = $pulp::node_certificate,
   $verify_ssl = $pulp::node_verify_ssl,

--- a/manifests/child/fragment.pp
+++ b/manifests/child/fragment.pp
@@ -1,9 +1,11 @@
-# provides the ability to specify fragments for the ssl 
-#   virtual host defined for a pulp node
+# provides the ability to specify fragments for the ssl virtual host defined
+# for a pulp node
 #
-#  === Parameters:
+# @param ssl_content
+#   Content of the ssl virtual host fragment
 #
-#  $ssl_content:: content of the ssl virtual host fragment
+# @param order
+#   The relative order compared to other fragments
 define pulp::child::fragment(
   $ssl_content = undef,
   $order       = 15,

--- a/manifests/child/install.pp
+++ b/manifests/child/install.pp
@@ -1,4 +1,5 @@
 # Pulp Node Install Packages
+# @api private
 class pulp::child::install (
   $packages = ['pulp-katello', 'pulp-nodes-child', 'katello-agent'],
 ) {

--- a/manifests/child/service.pp
+++ b/manifests/child/service.pp
@@ -1,4 +1,5 @@
 # Pulp Node Service
+# @api private
 class pulp::child::service(
   $service = 'goferd',
   $ensure = 'running',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,5 @@
 # Pulp Master Configuration
-# Private class
+# @api private
 class pulp::config {
   file { '/var/lib/pulp/packages':
     ensure => directory,

--- a/manifests/consumer.pp
+++ b/manifests/consumer.pp
@@ -1,96 +1,136 @@
-#
-# == Class: pulp::consumer
-#
 # Install and configure Pulp consumers
 #
-# === Parameters:
+# @param ca_path
+#   Path to use for the CA
 #
-# $ca_path::                       Path to use for the CA
+# @param version
+#   pulp admin package version, it's passed to ensure parameter of package
+#   resource can be set to specific version number, 'latest', 'present' etc.
 #
-# $version::                       pulp admin package version, it's passed to ensure parameter of package resource
-#                                  can be set to specific version number, 'latest', 'present' etc.
+# @param enable_puppet
+#   Install puppet extension
 #
-# $enable_puppet::                 Install puppet extension. Only available on pulp 2.6 and higher
+# @param enable_nodes
+#   Install nodes extension
 #
-# $enable_nodes::                  Install nodes extension
+# @param enable_rpm
+#   Install rpm extension
 #
-# $enable_rpm::                    Install rpm extension
+# @param host
+#   The pulp server hostname
 #
-# $host::                          The pulp server hostname
+# @param port
+#   The port providing the RESTful API
 #
-# $port::                          The port providing the RESTful API
+# @param api_prefix
+#   The REST API prefix.
 #
-# $api_prefix::                    The REST API prefix.
+# @param verify_ssl
+#   Set this to False to configure the client not to verify that the server's
+#   SSL cert is signed by a trusted authority
 #
-# $verify_ssl::                    Set this to False to configure the client not to verify that the server's SSL cert is signed by
-#                                  a trusted authority
+# @param rsa_server_pub
+#   The pulp server public key used for authentication.
 #
-# $rsa_server_pub::                The pulp server public key used for authentication.
+# @param rsa_key
+#   The RSA private key used for authentication.
 #
-# $rsa_key::                       The RSA private key used for authentication.
+# @param rsa_pub
+#   The RSA public key used for authentication.
 #
-# $rsa_pub::                       The RSA public key used for authentication.
+# @param role
+#   The client role.
 #
-# $role::                          The client role.
+# @param extensions_dir
+#   The location of consumer client extensions.
 #
-# $extensions_dir::                The location of consumer client extensions.
+# @param repo_file
+#   The location of the YUM repository file managed by pulp.
 #
-# $repo_file::                     The location of the YUM repository file managed by pulp.
+# @param mirror_list_dir
+#   The location of the directory containing YUM mirror list files that are
+#   managed by Pulp.
 #
-# $mirror_list_dir::               The location of the directory containing YUM mirror list files that are managed by Pulp.
+# @param gpg_keys_dir
+#   The location of downloaded GPG keys stored by Pulp. The path to the keys
+#   stored here are referenced by Pulp's YUM repository file.
 #
-# $gpg_keys_dir::                  The location of downloaded GPG keys stored by Pulp. The path to the
-#                                  keys stored here are referenced by Pulp's YUM repository file.
+# @param cert_dir
+#   The location of downloaded X.509 certificates stored by Pulp. The path to
+#   the certificates stored here are referenced by Pulp's YUM repository file.
 #
-# $cert_dir::                      The location of downloaded X.509 certificates stored by Pulp. The path to
-#                                  the certificates stored here are referenced by Pulp's YUM repository file.
+# @param id_cert_dir
+#   The location of the directory where the Pulp consumer ID certificate is stored.
 #
-# $id_cert_dir::                   The location of the directory where the Pulp consumer ID certificate is stored.
+# @param id_cert_filename
+#   The name of the file containing the PEM encoded consumer private key and
+#   X.509 certificate. This file is downloaded and stored here during
+#   registration.
 #
-# $id_cert_filename::              The name of the file containing the PEM encoded consumer private key and X.509
-#                                  certificate. This file is downloaded and stored here during registration.
+# @param reboot_permit
+#   Permit reboots after package installs if requested.
 #
-# $reboot_permit::                 Permit reboots after package installs if requested.
+# @param reboot_delay
+#   The reboot delay (minutes).
 #
-# $reboot_delay::                  The reboot delay (minutes).
+# @param logging_filename
+#   The location of the consumer client log file.
 #
-# $logging_filename::              The location of the consumer client log file.
+# @param logging_call_log_filename
+#   If present, the raw REST responses will be logged to the given file.
 #
-# $logging_call_log_filename::     If present, the raw REST responses will be logged to the given file.
+# @param poll_frequency_in_seconds
+#   Number of seconds between requests for any operation that repeatedly polls
+#   the server for data.
 #
-# $poll_frequency_in_seconds::     Number of seconds between requests for any operation that repeatedly polls
-#                                  the server for data.
+# @param enable_color
+#   Set this to false to disable all color escape sequences
 #
-# $enable_color::                  Set this to false to disable all color escape sequences
+# @param wrap_to_terminal
+#   If wrap_to_terminal is true, any text wrapping will use the current width
+#   of the terminal. If false, the value in wrap_width is used.
 #
-# $wrap_to_terminal::              If wrap_to_terminal is true, any text wrapping will use the current width of
-#                                  the terminal. If false, the value in wrap_width is used.
+# @param wrap_width
+#   The number of characters written before wrapping to the next line.
 #
-# $wrap_width::                    The number of characters written before wrapping to the next line.
+# @param messaging_scheme
+#   The broker URL scheme. Either 'tcp' or 'ssl' can be used. The default is 'tcp'.
 #
-# $messaging_scheme::              The broker URL scheme. Either 'tcp' or 'ssl' can be used. The default is 'tcp'.
+# @param messaging_host
+#   The broker host (default: host defined in [server]).
 #
-# $messaging_host::                The broker host (default: host defined in [server]).
+# @param messaging_port
+#   The broker port number. The default is 5672.
 #
-# $messaging_port::                The broker port number. The default is 5672.
+# @param messaging_transport
+#   The AMQP transport name. Valid options are 'qpid' or 'rabbitmq'. The
+#   default is 'qpid'.
 #
-# $messaging_transport::           The AMQP transport name. Valid options are 'qpid' or 'rabbitmq'. The default is 'qpid'.
+# @param messaging_vhost
+#   The (optional) broker vhost. This is only valid when using 'rabbitmq' as
+#   the messaging_transport.
 #
-# $messaging_vhost::               The (optional) broker vhost. This is only valid when using 'rabbitmq' as the messaging_transport.
+# @param messaging_version
+#   Determines the version of packages related to the 'messaging transport
+#   protocol'.
 #
-# $messaging_version::             Determines the version of packages related to the 'messaging transport protocol'.
+# @param messaging_cacert
+#   The (optional) absolute path to a PEM encoded CA certificate to validate
+#   the identity of the broker.
 #
-# $messaging_cacert::              The (optional) absolute path to a PEM encoded CA certificate to validate the identity of the
-#                                  broker.
+# @param messaging_clientcert
+#   The optional absolute path to PEM encoded key & certificate used to
+#   authenticate to the broker with. The id_cert_dir and id_cert_filename are
+#   used if this is not defined.
 #
-# $messaging_clientcert::          The optional absolute path to PEM encoded key & certificate used to authenticate to the broker
-#                                  with. The id_cert_dir and id_cert_filename are used if this is not defined.
+# @param profile_minutes
+#   The interval in minutes for reporting the installed content profiles.
 #
-# $profile_minutes::               The interval in minutes for reporting the installed content profiles.
+# @param package_profile_enabled
+#   Updates package profile information for a registered consumer on pulp server
 #
-# $package_profile_enabled::       Updates package profile information for a registered consumer on pulp server
-#
-# $package_profile_verbose::       Set logging level
+# @param package_profile_verbose
+#   Set logging level
 #
 class pulp::consumer (
   String $version = $pulp::consumer::params::version,

--- a/manifests/consumer/config.pp
+++ b/manifests/consumer/config.pp
@@ -1,4 +1,5 @@
 # Pulp Consumer Configuration
+# @api private
 class pulp::consumer::config {
   file { '/etc/pulp/consumer/consumer.conf':
     ensure  => 'file',

--- a/manifests/consumer/install.pp
+++ b/manifests/consumer/install.pp
@@ -1,4 +1,5 @@
 # Pulp Consumer Install Packages
+# @api private
 class pulp::consumer::install {
   if $pulp::consumer::messaging_transport == 'qpid' {
     ensure_packages(['python-gofer-qpid'], {

--- a/manifests/consumer/params.pp
+++ b/manifests/consumer/params.pp
@@ -1,4 +1,5 @@
 # Pulp Consumer Params
+# @api private
 class pulp::consumer::params {
   $version = 'installed'
   $enable_puppet = false

--- a/manifests/consumer/service.pp
+++ b/manifests/consumer/service.pp
@@ -1,4 +1,5 @@
 # Pulp Consumer Service Packages
+# @api private
 class pulp::consumer::service {
   service { 'goferd':
     ensure     => running,

--- a/manifests/crane.pp
+++ b/manifests/crane.pp
@@ -1,26 +1,34 @@
-# == Class: pulp::crane
-#
 # Install and configure Crane
 #
-# === Parameters:
+# @param debug
+#   Enable debug logging
 #
-# $debug::                      Enable debug logging
+# @param server_name
+#   The server name on the vhost
 #
-# $key::                        Path to the SSL key for https
+# @param key
+#   Path to the SSL key for https
 #
-# $cert::                       Path to the SSL certificate for https
+# @param cert
+#   Path to the SSL certificate for https
 #
-# $ca_cert::                    Path to the SSL CA cert for https
+# @param ca_cert
+#   Path to the SSL CA cert for https
 #
-# $ssl_chain::                  Path to the SSL chain file for https
+# @param ssl_chain
+#   Path to the SSL chain file for https
 #
-# $port::                       Port for Crane to run on
+# @param port
+#   Port for Crane to run on
 #
-# $data_dir::                   Directory containing docker v1/v2 artifacts published by pulp
+# @param data_dir
+#   Directory containing docker v1/v2 artifacts published by pulp
 #
-# $data_dir_polling_interval::  The number of seconds between checks for updates to metadata files in the data_dir
+# @param data_dir_polling_interval
+#   The number of seconds between checks for updates to metadata files in the data_dir
 #
-# $ssl_protocol::               SSLProtocol configuration to use
+# @param ssl_protocol
+#   SSLProtocol configuration to use
 class pulp::crane (
   Stdlib::Absolutepath $key,
   Stdlib::Absolutepath $cert,

--- a/manifests/crane/apache.pp
+++ b/manifests/crane/apache.pp
@@ -1,4 +1,5 @@
 # Sets up Apache for Crane
+# @api private
 class pulp::crane::apache {
 
   include apache

--- a/manifests/crane/config.pp
+++ b/manifests/crane/config.pp
@@ -1,4 +1,5 @@
 # Configure Crane
+# @api private
 class pulp::crane::config {
   file { '/etc/crane.conf':
     ensure  => 'file',

--- a/manifests/crane/install.pp
+++ b/manifests/crane/install.pp
@@ -1,4 +1,5 @@
 # Install Crane and dependencies
+# @api private
 class pulp::crane::install {
 
   package{ ['python-crane']:

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -1,4 +1,5 @@
 # Set up the pulp database
+# @api private
 class pulp::database {
   if $pulp::manage_db {
     include mongodb::server

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,281 +1,405 @@
-# == Class: pulp
-#
 # Install and configure pulp
 #
-# === Parameters:
+# @param version
+#   pulp package version, it's passed to ensure parameter of package resource
+#   can be set to specific version number, 'latest', 'present' etc.
 #
-# $version::                    pulp package version, it's passed to ensure parameter of package resource can be set to
-#                               specific version number, 'latest', 'present' etc.
+# @param crane_debug
+#   Whether to enable crane debug logging
 #
-# $crane_debug::                Whether to enable crane debug logging
+# @param crane_port
+#   Port for Crane to run on
 #
-# $crane_port::                 Port for Crane to run on
+# @param crane_data_dir
+#   Directory containing docker v1/v2 artifacts published by pulp
 #
-# $crane_data_dir::             Directory containing docker v1/v2 artifacts published by pulp
+# @param manage_repo
+#   Whether to manage the pulp repository
 #
-# $manage_repo::                Whether to manage the pulp repository
+# @param oauth_key
+#   Key to enable OAuth style authentication
 #
-# $oauth_key::                  Key to enable OAuth style authentication
+# @param oauth_secret
+#   Shared secret that can be used for OAuth style authentication
 #
-# $oauth_secret::               Shared secret that can be used for OAuth style authentication
+# @param oauth_enabled
+#   Controls whether OAuth authentication is enabled
 #
-# $oauth_enabled::              Controls whether OAuth authentication is enabled
+# @param messaging_url
+#   the url used to contact the broker:
+#   <protocol>://<host>:<port>/<virtual-host> Supported <protocol>  values are
+#   'tcp' or 'ssl' depending on if SSL should be used or not. The
+#   <virtual-host> is optional, and is only applicable to RabbitMQ broker
+#   environments.
 #
-# $messaging_url::              the url used to contact the broker: <protocol>://<host>:<port>/<virtual-host>
-#                               Supported <protocol>  values are 'tcp' or 'ssl' depending on if SSL should be used or not.
-#                               The <virtual-host> is optional, and is only applicable to RabbitMQ broker environments.
+# @param messaging_transport
+#   The type of broker you are connecting to.
 #
-# $messaging_transport::        The type of broker you are connecting to.
+# @param messaging_ca_cert
+#   Absolute path to PEM encoded CA certificate file, used by Pulp to validate
+#   the identity of the broker using SSL.
 #
-# $messaging_ca_cert::          Absolute path to PEM encoded CA certificate file, used by Pulp to validate the identity
-#                               of the broker using SSL.
+# @param messaging_client_cert
+#   Absolute path to PEM encoded file containing both the private key and
+#   certificate Pulp should present to the broker to be authenticated by the
+#   broker.
 #
-# $messaging_client_cert::      Absolute path to PEM encoded file containing both the private key and certificate Pulp
-#                               should present to the broker to be authenticated by the broker.
+# @param messaging_version
+#   Determines the version of packages related to the 'messaging transport protocol'.
 #
-# $messaging_version::          Determines the version of packages related to the 'messaging transport protocol'.
+# @param broker_url
+#   A URL to a broker that Celery can use to queue tasks:
+#   qpid://<username>:<password>@<hostname>:<port>/
 #
-# $broker_url::                 A URL to a broker that Celery can use to queue tasks:
-#                               qpid://<username>:<password>@<hostname>:<port>/
+# @param broker_use_ssl
+#   Whether to require SSL.
 #
-# $broker_use_ssl::             Whether to require SSL.
+# @param tasks_login_method
+#   Select the SASL login method used to connect to the broker. This should be
+#   left unset except in special cases such as SSL client certificate
+#   authentication.
 #
-# $tasks_login_method::         Select the SASL login method used to connect to the broker. This should be left unset
-#                               except in special cases such as SSL client certificate authentication.
+# @param ca_cert
+#   Full path to the CA certificate that will be used to sign consumer and
+#   admin identification certificates; this must match the value of
+#   SSLCACertificateFile in Apache.
 #
-# $ca_cert::                    Full path to the CA certificate that will be used to sign consumer and admin
-#                               identification certificates; this must match the value of SSLCACertificateFile in
-#                               Apache.
+# @param ca_key
+#   Path to the private key for the above CA certificate
 #
-# $ca_key::                     Path to the private key for the above CA certificate
+# @param db_name
+#   Name of the database to use
 #
-# $db_name::                    Name of the database to use
+# @param db_seeds
+#   Comma-separated list of hostname:port of database replica seed hosts
 #
-# $db_seeds::                   Comma-separated list of hostname:port of database replica seed hosts
+# @param db_username
+#   The user name to use for authenticating to the MongoDB server
 #
-# $db_username::                The user name to use for authenticating to the MongoDB server
+# @param db_password
+#   The password to use for authenticating to the MongoDB server
 #
-# $db_password::                The password to use for authenticating to the MongoDB server
+# @param db_replica_set
+#   The name of replica set configured in MongoDB, if one is in use
 #
-# $db_replica_set::             The name of replica set configured in MongoDB, if one is in use
+# @param db_ssl
+#   Whether to connect to the database server using SSL.
 #
-# $db_ssl::                     Whether to connect to the database server using SSL.
+# @param db_ssl_keyfile
+#   A path to the private keyfile used to identify the local connection
+#   against mongod. If included with the certfile then only the ssl_certfile
+#   is needed.
 #
-# $db_ssl_keyfile::             A path to the private keyfile used to identify the local connection against mongod. If
-#                               included with the certfile then only the ssl_certfile is needed.
+# @param db_ssl_certfile
+#   The certificate file used to identify the local connection against mongod.
 #
-# $db_ssl_certfile::            The certificate file used to identify the local connection against mongod.
+# @param db_verify_ssl
+#   Specifies whether a certificate is required from the other side of the
+#   connection, and whether it will be validated if provided. If it is true,
+#   then the ca_certs parameter must point to a file of CA certificates used
+#   to validate the connection.
 #
-# $db_verify_ssl::              Specifies whether a certificate is required from the other side of the connection, and
-#                               whether it will be validated if provided. If it is true, then the ca_certs parameter
-#                               must point to a file of CA certificates used to validate the connection.
+# @param db_ca_path
+#   The ca_certs file contains a set of concatenated "certification authority"
+#   certificates, which are used to validate certificates passed from the
+#   other end of the connection.
 #
-# $db_ca_path::                 The ca_certs file contains a set of concatenated "certification authority" certificates,
-#                               which are used to validate certificates passed from the other end of the connection.
+# @param db_unsafe_autoretry
+#   If true, retry commands to the database if there is a connection error.
+#   Warning: if set to true, this setting can result in duplicate records.
 #
-# $db_unsafe_autoretry::        If true, retry commands to the database if there is a connection error.
-#                               Warning: if set to true, this setting can result in duplicate records.
+# @param db_write_concern
+#   Write concern of 'majority' or 'all'. When 'all' is specified, 'w' is set
+#   to number of seeds specified. For version of MongoDB < 2.6, replica_set
+#   must also be specified. Please note that 'all' will cause Pulp to halt if
+#   any of the replica set members is not available. 'majority' is used by
+#   default
 #
-# $db_write_concern::           Write concern of 'majority' or 'all'. When 'all' is specified, 'w' is set to number of
-#                               seeds specified. For version of MongoDB < 2.6, replica_set must also be specified.
-#                               Please note that 'all' will cause Pulp to halt if any of the replica set members is not
-#                               available. 'majority' is used by default
+# @param server_name
+#   Hostname the admin client and consumers should use when accessing the server
 #
-# $server_name::                Hostname the admin client and consumers should use when accessing the server
+# @param key_url
+#   Path within the URL to use for GPG keys
 #
-# $key_url::                    Path within the URL to use for GPG keys
+# @param ks_url
+#   Path within the URL to use for kickstart trees
 #
-# $ks_url::                     Path within the URL to use for kickstart trees
+# @param debugging_mode
+#   Whether to enable Pulp's debugging capabilities
 #
-# $debugging_mode::             Whether to enable Pulp's debugging capabilities
+# @param log_level
+#   The desired logging level.
 #
-# $log_level::                  The desired logging level. Options are: CRITICAL, ERROR, WARNING, INFO, DEBUG, and
-#                               NOTSET.
+# @param log_type
+#   The desired logging type: Options are: syslog, console
 #
-# $log_type::                   The desired logging type: Options are: syslog, console
+# @param server_working_directory
+#   Path to where pulp workers can create working directories needed to complete tasks
 #
-# $server_working_directory::   Path to where pulp workers can create working directories needed to complete tasks
+# @param rsa_key
+#   The RSA private key used for authentication.
 #
-# $rsa_key::                    The RSA private key used for authentication.
+# @param rsa_pub
+#   The RSA public key used for authentication.
 #
-# $rsa_pub::                    The RSA public key used for authentication.
+# @param https_cert
+#   Apache public certificate for ssl
 #
-# $https_cert::                 Apache public certificate for ssl
+# @param https_key
+#   Apache private certificate for ssl
 #
-# $https_key::                  Apache private certificate for ssl
+# @param https_chain
+#   apache chain file for ssl
 #
-# $https_chain::                apache chain file for ssl
+# @param ssl_username
+#   Value to use for SSLUsername directive in apache vhost. Defaults to
+#   SSL_CLIENT_S_DN_CN. Set an empty string or false to unset directive.
 #
-# $ssl_username::               Value to use for SSLUsername directive in apache vhost. Defaults to SSL_CLIENT_S_DN_CN.
-#                               Set an empty string or false to unset directive.
+# @param consumers_crl
+#   Certificate revocation list for consumers which are no valid (have had
+#   their client certs revoked)
 #
-# $consumers_crl::              Certificate revocation list for consumers which are no valid (have had their client
-#                               certs revoked)
+# @param user_cert_expiration
+#   Number of days a user certificate is valid
 #
-# $user_cert_expiration::       Number of days a user certificate is valid
+# @param default_login
+#   Default admin username of the Pulp server; this user will be the first
+#   time the server is started
 #
-# $default_login::              Default admin username of the Pulp server; this user will be the first time the server
-#                               is started
+# @param default_password
+#   Default password for admin when it is first created; this should be
+#   changed once the server is operational
 #
-# $default_password::           Default password for admin when it is first created; this should be changed once the
-#                               server is operational
+# @param repo_auth
+#   Whether to determine whether repos managed by pulp will require authentication.
 #
-# $repo_auth::                  Whether to determine whether repos managed by pulp will require authentication.
+# @param consumer_cert_expiration
+#   Number of days a consumer certificate is valid
 #
-# $consumer_cert_expiration::   Number of days a consumer certificate is valid
+# @param disabled_authenticators
+#   List of repo authenticators to disable.
 #
-# $disabled_authenticators::    List of repo authenticators to disable.
+# @param additional_wsgi_scripts
+#   Hash of additional paths and WSGI script locations for Pulp vhost
 #
-# $additional_wsgi_scripts::    Hash of additional paths and WSGI script locations for Pulp vhost
+# @param reset_cache
+#   Whether to force a cache flush. Not recommend in a regular puppet environment.
 #
-# $reset_cache::                Whether to force a cache flush. Not recommend in a regular puppet environment.
+# @param ssl_verify_client
+#   Enforce use of SSL authentication for yum repos access
 #
-# $ssl_verify_client::          Enforce use of SSL authentication for yum repos access
+# @param ssl_protocol
+#   Versions of the SSL/TLS protocol will be accepted in new connections
 #
-# $ssl_protocol::               Versions of the SSL/TLS protocol will be accepted in new connections
+# @param serial_number_path
+#   Path to the serial number file
 #
-# $serial_number_path::         Path to the serial number file
+# @param consumer_history_lifetime
+#   number of days to store consumer events; events older than this will be
+#   purged; set to -1 to disable
 #
-# $consumer_history_lifetime::  number of days to store consumer events; events older
-#                               than this will be purged; set to -1 to disable
+# @param messaging_url
+#   the url used to contact the broker:
+#   <protocol>://<host>:<port>/<virtual-host> Supported <protocol>  values are
+#   'tcp' or 'ssl' depending on if SSL should be used or not.  The
+#   <virtual-host> is optional, and is only applicable to RabbitMQ broker
+#   environments.
 #
-# $messaging_url::              the url used to contact the broker: <protocol>://<host>:<port>/<virtual-host>
-#                               Supported <protocol>  values are 'tcp' or 'ssl' depending on if SSL should be used or not.
-#                               The <virtual-host> is optional, and is only applicable to RabbitMQ broker environments.
+# @param messaging_auth_enabled
+#   Whether to enable message authentication.
 #
-# $messaging_auth_enabled::     Whether to enable message authentication.
+# @param messaging_topic_exchange
+#   The name of the exchange to use. The exchange must be a topic exchange.
+#   The default 'amq.topic' is a default exchange that is guaranteed to exist
+#   on a Qpid broker.
 #
-# $messaging_topic_exchange::   The name of the exchange to use. The exchange must be a topic exchange. The
-#                               default 'amq.topic' is a default exchange that is guaranteed to exist on a Qpid broker.
+# @param messaging_event_notifications_enabled
+#   Whether to enable Pulp event notfications on the message bus.
 #
-# $messaging_event_notifications_enabled:: Whether to enable Pulp event notfications on the message bus.
+# @param messaging_event_notification_url
+#   The AMQP URL for event notifications.
 #
-# $messaging_event_notification_url:: The AMQP URL for event notifications.
+# @param email_host
+#   Hostname of the MTA pulp should relay through
 #
-# $email_host::                 Hostname of the MTA pulp should relay through
+# @param email_port
+#   Port of the MTA relay
 #
-# $email_port::                 Port of the MTA relay
+# @param email_from
+#   The "From" address of each email the system sends
 #
-# $email_from::                 The "From" address of each email the system sends
+# @param email_enabled
+#   Whether emails will be sent
 #
-# $email_enabled::              Whether emails will be sent
+# @param manage_squid
+#   Whether the Squid configuration is managed. This is used by Pulp Streamer.
+#   Requires the squid module.
 #
-# $manage_squid::               Whether the Squid configuration is managed. This is used by Pulp Streamer.
-#                               Requires the squid module.
+# @param lazy_redirect_host
+#   The host FQDN or IP to which requests are redirected.
 #
-# $lazy_redirect_host::         The host FQDN or IP to which requests are redirected.
+# @param lazy_redirect_port
+#   The TCP port to which requests are redirected
 #
-# $lazy_redirect_port::         The TCP port to which requests are redirected
+# @param lazy_redirect_path
+#   The base path to which requests are redirected
 #
-# $lazy_redirect_path::         The base path to which requests are redirected
+# @param lazy_https_retrieval
+#   Controls whether Pulp uses HTTPS or HTTP to retrieve content from the streamer.
+#   WARNING: Setting this to 'false' is not safe if you wish to use Pulp to
+#   provide repository entitlement enforcement.  It is strongly recommended to
+#   keep this set to 'true' and use certificates that are signed by a trusted
+#   authority on the web server that serves as the streamer reverse proxy.
 #
-# $lazy_https_retrieval::       controls whether Pulp uses HTTPS or HTTP to retrieve content from the streamer.
-#                               WARNING: Setting this to 'false' is not safe if you wish to use Pulp to provide
-#                               repository entitlement enforcement.  It is strongly recommended to keep this set to
-#                               'true' and use certificates that are signed by a trusted authority on the web server
-#                               that serves as the streamer reverse proxy.
+# @param lazy_download_interval
+#   The interval in minutes between checks for content cached by the Squid proxy.
 #
-# $lazy_download_interval::     The interval in minutes between checks for content cached by the Squid proxy.
+# @param lazy_download_concurrency
+#   The number of downloads to perform concurrently when downloading content
+#   from the Squid cache.
 #
-# $lazy_download_concurrency::  The number of downloads to perform concurrently when downloading content from the Squid
-#                               cache.
+# @param proxy_url
+#   URL of the proxy server
 #
-# $proxy_url::                  URL of the proxy server
+# @param proxy_port
+#   Port the proxy is running on
 #
-# $proxy_port::                 Port the proxy is running on
+# @param proxy_username
+#   Proxy username for authentication
 #
-# $proxy_username::             Proxy username for authentication
+# @param proxy_password
+#   Proxy password for authentication
 #
-# $proxy_password::             Proxy password for authentication
+# @param yum_max_speed
+#   The maximum download speed for RPM & ISO Pulp tasks, such as a sync. (e.g.
+#   "4 kb" or "1 Gb")
 #
-# $yum_max_speed::              The maximum download speed for RPM & ISO Pulp tasks, such as a sync. (e.g. "4 kb" or "1 Gb")
+# @param yum_gpg_sign_repo_metadata
+#   Whether yum repo metadata GPG signing will be enabled
 #
-# $yum_gpg_sign_repo_metadata:: Whether yum repo metadata GPG signing will be enabled
+# @param num_workers
+#   Number of Pulp workers to use.
 #
-# $num_workers::                Number of Pulp workers to use.
+# @param enable_admin
+#   Whether to install and configure the admin command
 #
-# $enable_admin::               Whether to install and configure the admin command
+# @param enable_katello
+#   Whether to enable pulp katello plugin.
 #
-# $enable_katello::             Whether to enable pulp katello plugin.
+# @param enable_crane
+#   Whether to enable crane docker repository
 #
-# $enable_crane::               Whether to enable crane docker repository
+# @param max_tasks_per_child
+#   Number of tasks after which the worker is restarted and the memory it
+#   allocated is returned to the system
 #
-# $max_tasks_per_child::        Number of tasks after which the worker is restarted and the memory it allocated is
-#                               returned to the system
+# @param enable_rpm
+#   Whether to enable rpm plugin.
 #
-# $enable_rpm::                 Whether to enable rpm plugin.
+# @param enable_deb
+#   Whether to enable deb plugin.
 #
-# $enable_deb::                 Whether to enable deb plugin.
+# @param enable_iso
+#   Whether to enable iso plugin.
 #
-# $enable_iso::                 Whether to enable iso plugin.
+# @param enable_docker
+#   Whether to enable docker plugin.
 #
-# $enable_docker::              Whether to enable docker plugin.
+# @param enable_puppet
+#   Whether to enable puppet plugin.
 #
-# $enable_puppet::              Whether to enable puppet plugin.
+# @param enable_python
+#   Whether to enable python plugin.
 #
-# $enable_python::              Whether to enable python plugin.
+# @param enable_ostree
+#   Whether to enable ostree plugin.
 #
-# $enable_ostree::              Whether to enable ostree plugin.
+# @param enable_parent_node
+#   Whether to enable pulp parent nodes.
 #
-# $enable_parent_node::         Whether to enable pulp parent nodes.
+# @param enable_http
+#   Whether to enable http access to deb/rpm repos.
 #
-# $enable_http::                Whether to enable http access to deb/rpm repos.
+# @param http_port
+#   HTTP port Apache will listen
 #
-# $http_port::                  HTTP port Apache will listen
+# @param https_port
+#   HTTPS port Apache will listen
 #
-# $https_port::                 HTTPS port Apache will listen
+# @param manage_httpd
+#   Whether to install and configure the httpd server.
 #
-# $manage_httpd::               Whether to install and configure the httpd server.
+# @param manage_plugins_httpd
+#   Whether to install the enabled pulp plugins apache configs even if
+#   $manage_httpd is false.
 #
-# $manage_plugins_httpd::       Whether to install the enabled pulp plugins apache configs even if $manage_httpd is
-#                               false.
+# @param manage_broker
+#   Whether install and configure the qpid or rabbitmq broker.
 #
-# $manage_broker::              Whether install and configure the qpid or rabbitmq broker.
+# @param manage_db
+#   Boolean to install and configure the mongodb.
 #
-# $manage_db::                  Boolean to install and configure the mongodb.
+# @param node_certificate
+#   The absolute path to the node SSL certificate
 #
-# $node_certificate::           The absolute path to the node SSL certificate
+# @param node_verify_ssl
+#   Whether to verify node SSL
 #
-# $node_verify_ssl::            Whether to verify node SSL
+# @param node_server_ca_cert
+#   Server cert for pulp node
 #
-# $node_server_ca_cert::        Server cert for pulp node
+# @param node_oauth_effective_user
+#   Effective user for node OAuth
 #
-# $node_oauth_effective_user::  Effective user for node OAuth
+# @param node_oauth_key
+#   The oauth key used to authenticate to the parent node
 #
-# $node_oauth_key::             The oauth key used to authenticate to the parent node
+# @param node_oauth_secret
+#   The oauth secret used to authenticate to the parent node
 #
-# $node_oauth_secret::          The oauth secret used to authenticate to the parent node
+# @param max_keep_alive
+#   Configuration value for apache MaxKeepAliveRequests
 #
-# $max_keep_alive::             Configuration value for apache MaxKeepAliveRequests
+# @param wsgi_processes
+#   Number of WSGI processes to spawn for pulp itself
 #
-# $wsgi_processes::             Number of WSGI processes to spawn for pulp itself
+# @param wsgi_max_requests
+#   Maximum number of requests for each wsgi worker to process before shutting
+#   down and restarting, useful to combat memory leaks.
 #
-# $wsgi_max_requests::          Maximum number of requests for each wsgi worker to process before
-#                               shutting down and restarting, useful to combat memory leaks.
+# @param puppet_wsgi_processes
+#   Number of WSGI processes to spawn for the puppet webapp
 #
-# $puppet_wsgi_processes::      Number of WSGI processes to spawn for the puppet webapp
+# @param migrate_db_timeout
+#   Change the timeout for pulp-manage-db
 #
-# $migrate_db_timeout::         Change the timeout for pulp-manage-db
+# @param show_conf_diff
+#   Allow showing diff for changes in server.conf and importer.json.
+#   Warning: may display and log passwords contained in these files.
 #
-# $show_conf_diff::             Allow showing diff for changes in server.conf and importer.json;
-#                               Warning: may display and log passwords contained in these files.
+# @param enable_profiling
+#   Turns on cProfiling of tasks in Pulp
 #
-# $enable_profiling::           Turns on cProfiling of tasks in Pulp
+# @param profiling_directory
+#   Directory to store task profiling data in
 #
-# $profiling_directory::        Directory to store task profiling data in
+# @param ldap_url
+#   URL to use for LDAP authentication. Defaults to undef (internal
+#   authentication is used)
 #
-# $ldap_url::                   URL to use for LDAP authentication. Defaults
-#                               to undef (internal authentication is used)
+# @param ldap_bind_dn
+#   LDAP Bind DN
 #
-# $ldap_bind_dn::               LDAP Bind DN
+# @param ldap_bind_password
+#   LDAP Password
 #
-# $ldap_bind_password::         LDAP Password
+# @param ldap_remote_user_attribute
+#   LDAP Remote User Attribute. Defaults to 'sAMAccountName'
 #
-# $ldap_remote_user_attribute:: LDAP Remote User Attribute. Defaults to 'sAMAccountName'
-#
-# $worker_timeout::             The amount of time (in seconds) before considering a worker as missing. If Pulp's
-#                               mongo database has slow I/O, then setting a higher number may resolve issues where workers are
-#                               going missing incorrectly. Defaults to 30.
+# @param worker_timeout
+#   The amount of time (in seconds) before considering a worker as missing. If
+#   Pulp's mongo database has slow I/O, then setting a higher number may
+#   resolve issues where workers are going missing incorrectly. Defaults to 30.
 #
 class pulp (
   String $version = $pulp::params::version,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,5 @@
 # Pulp Installation Packages
-# Private class
+# @api private
 class pulp::install {
   package { ['pulp-server', 'pulp-selinux', 'python-pulp-streamer']: ensure => $pulp::version, }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
 # Pulp Master Params
-# Private class
+# @api private
 class pulp::params {
   $version = 'installed'
 

--- a/manifests/repo/upstream.pp
+++ b/manifests/repo/upstream.pp
@@ -1,3 +1,5 @@
+# Create the yum repo definition for the upstream repository
+# @api private
 class pulp::repo::upstream(
   $version = 2,
 ) {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,4 +1,5 @@
 # Pulp Master Service
+# @api private
 class pulp::service {
   exec { 'pulp refresh system service':
     command     => '/bin/systemctl daemon-reload',

--- a/manifests/squid.pp
+++ b/manifests/squid.pp
@@ -1,4 +1,5 @@
 # The class to manage squid. This is used by pulp streamer.
+# @api private
 class pulp::squid(
   Stdlib::Port $port = 3128,
   Stdlib::Host $streamer_host = '127.0.0.1',


### PR DESCRIPTION
This converts the documentation from RDoc to Yardoc. The benefit is that puppet-strings can read it which allows easy generation of reference documentation (`rake strings:generate:reference`). The only benefit of RDoc over Yardoc is support for groups which the installer can use to hide advanced sections, but this module isn't exposed by the installer and didn't have any groups.

For the 6.0.0 release I did this locally which results in https://forge.puppet.com/katello/pulp/reference. There are still some issues:
* `<` and `>` are not escaped which means various examples aren't very usable.
* Longer term it also makes sense to move static defaults from ::params to the main class so it can statically read the default.
* Some native types lack documentation