### PR TITLE
Drop support for Apache 2.2

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -8,8 +8,6 @@ class pulp::apache {
   include apache::mod::ssl
   include apache::mod::xsendfile
 
-  $apache_version = $apache::apache_version
-
   if $pulp::manage_httpd {
     if $pulp::enable_http or $pulp::enable_puppet {
       apache::vhost { 'pulp-http':

--- a/templates/pulp.conf.erb
+++ b/templates/pulp.conf.erb
@@ -24,11 +24,7 @@ WSGIScriptAlias /pulp/api /usr/share/pulp/wsgi/webservices.wsgi
 WSGIImportScript /usr/share/pulp/wsgi/webservices.wsgi process-group=pulp application-group=pulp
 
 <Directory /usr/share/pulp/wsgi>
-<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   Require all granted
-<% else -%>
-  Allow from all
-<% end -%>
 </Directory>
 
 <Files webservices.wsgi>
@@ -47,9 +43,5 @@ Alias /pulp/static /var/lib/pulp/static
 <Location /pulp/static>
     SSLRequireSSL
     Options +Indexes
-<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
-     Require all granted
-<% else -%>
-     Allow from all
-<% end -%>
+    Require all granted
 </Location>


### PR DESCRIPTION
We only list EL7 in our supported metadata. Since that ships Apache 2.4, we can safely drop Apache 2.2.