### PR TITLE
Add selinux_core to fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,6 +7,9 @@ fixtures:
     mongodb: "https://github.com/voxpupuli/puppet-mongodb.git"
     qpid:    "https://github.com/theforeman/puppet-qpid.git"
     selinux: "https://github.com/voxpupuli/puppet-selinux.git"
+    selinux_core:
+      repo: "https://github.com/puppetlabs/puppetlabs-selinux_core"
+      puppet_version: ">= 6.0.0"
     squid:   "https://github.com/voxpupuli/puppet-squid.git"
     systemd: 'https://github.com/camptocamp/puppet-systemd.git'
     yumrepo_core:


### PR DESCRIPTION
c230d7b621c7eb8e40c1143366425b4e99b51f37 started to use selboolean but on Puppet 6 this requires selinux_core to be added to the fixtures.