### PR TITLE
Drop default ssl_protocol and pass it to crane

### DIFF
--- a/manifests/crane.pp
+++ b/manifests/crane.pp
@@ -40,7 +40,7 @@ class pulp::crane (
   Stdlib::Absolutepath $data_dir = '/var/lib/crane/metadata',
   Integer[0] $data_dir_polling_interval = 60,
   Optional[Stdlib::Absolutepath] $ssl_chain = undef,
-  Optional[String] $ssl_protocol = undef,
+  Optional[Variant[Array[String], String]] $ssl_protocol = undef,
 ){
 
   contain pulp::crane::install

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -480,7 +480,7 @@ class pulp (
   Optional[Stdlib::Absolutepath] $consumers_crl = $pulp::params::consumers_crl,
   Boolean $reset_cache = $pulp::params::reset_cache,
   Enum['none', 'optional', 'require', 'optional_no_ca'] $ssl_verify_client = $pulp::params::ssl_verify_client,
-  Variant[Array[String], String] $ssl_protocol = $pulp::params::ssl_protocol,
+  Optional[Variant[Array[String], String]] $ssl_protocol = $pulp::params::ssl_protocol,
   Boolean $repo_auth = $pulp::params::repo_auth,
   Optional[String] $proxy_url = $pulp::params::proxy_url,
   Optional[Integer[1, 65535]] $proxy_port = $pulp::params::proxy_port,
@@ -551,13 +551,14 @@ class pulp (
 
   if $enable_crane {
     class { 'pulp::crane':
-      cert      => $https_cert,
-      key       => $https_key,
-      ca_cert   => pick($pulp::https_ca_cert, $pulp::ca_cert),
-      ssl_chain => $https_chain,
-      port      => $crane_port,
-      data_dir  => $crane_data_dir,
-      debug     => $crane_debug,
+      cert         => $https_cert,
+      key          => $https_key,
+      ca_cert      => pick($pulp::https_ca_cert, $pulp::ca_cert),
+      ssl_chain    => $https_chain,
+      port         => $crane_port,
+      data_dir     => $crane_data_dir,
+      debug        => $crane_debug,
+      ssl_protocol => $ssl_protocol,
     }
     contain pulp::crane
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,7 +64,7 @@ class pulp::params {
   $http_port = 80
   $https_port = 443
   $ssl_verify_client = 'require'
-  $ssl_protocol = ['all', '-SSLv2', '-SSLv3']
+  $ssl_protocol = undef
 
   $crane_debug = false
   $crane_port = 5000

--- a/spec/classes/pulp_apache_spec.rb
+++ b/spec/classes/pulp_apache_spec.rb
@@ -38,7 +38,7 @@ describe 'pulp::apache' do
         :ssl_chain               => nil,
         :ssl_ca                  => '/etc/pki/pulp/ca.crt',
         :ssl_verify_client       => 'optional',
-        :ssl_protocol            => ['all', '-SSLv2', '-SSLv3'],
+        :ssl_protocol            => nil,
         :ssl_options             => '+StdEnvVars +ExportCertData',
         :ssl_verify_depth        => '3',
         :wsgi_process_group      => 'pulp',


### PR DESCRIPTION
When enabling crane from the main class, the certificates are already matched. When the user has passed ssl_protocol to tighten the ciphers, they can also be passed to crane.

This also changes the default to undef which means the Apache default is used. This allows hardening the entire server without setting it for all separate vhosts.