### PR TITLE
Add support for different CA certificates for apache and pulp

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -81,7 +81,7 @@ class pulp::apache {
       ssl_cert                   => $pulp::https_cert,
       ssl_key                    => $pulp::https_key,
       ssl_chain                  => $pulp::https_chain,
-      ssl_ca                     => $pulp::ca_cert,
+      ssl_ca                     => $pulp::https_ca_cert,
       ssl_certs_dir              => '',
       ssl_verify_client          => 'optional',
       ssl_protocol               => $pulp::ssl_protocol,

--- a/manifests/child/apache.pp
+++ b/manifests/child/apache.pp
@@ -4,7 +4,7 @@ class pulp::child::apache (
   $servername = $facts['fqdn'],
   $ssl_cert = $pulp::child::ssl_cert,
   $ssl_key = $pulp::child::ssl_key,
-  $ssl_ca = $pulp::ca_cert,
+  $ssl_ca = $pulp::https_ca_cert,
   $max_keep_alive = $pulp::max_keep_alive,
   $ssl_username = $pulp::ssl_username,
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,8 +61,7 @@
 #
 # @param ca_cert
 #   Full path to the CA certificate that will be used to sign consumer and
-#   admin identification certificates; this must match the value of
-#   SSLCACertificateFile in Apache.
+#   admin identification certificates
 #
 # @param ca_key
 #   Path to the private key for the above CA certificate
@@ -147,6 +146,9 @@
 #
 # @param https_key
 #   Apache private certificate for ssl
+#
+# @param https_ca_cert
+#   Apache CA certificate for client authentication. Defaults to $ca_cert 
 #
 # @param https_chain
 #   apache chain file for ssl
@@ -439,6 +441,7 @@ class pulp (
   Stdlib::Absolutepath $ca_key = $pulp::params::ca_key,
   Optional[Stdlib::Absolutepath] $https_cert = $pulp::params::https_cert,
   Optional[Stdlib::Absolutepath] $https_key = $pulp::params::https_key,
+  Optional[Stdlib::Absolutepath] $https_ca_cert = $pulp::params::https_ca_cert,
   Optional[Stdlib::Absolutepath] $https_chain = $pulp::params::https_chain,
   Variant[String, Boolean] $ssl_username = $pulp::params::ssl_username,
   Integer $user_cert_expiration = $pulp::params::user_cert_expiration,
@@ -550,7 +553,7 @@ class pulp (
     class { 'pulp::crane':
       cert      => $https_cert,
       key       => $https_key,
-      ca_cert   => $ca_cert,
+      ca_cert   => $https_ca_cert,
       ssl_chain => $https_chain,
       port      => $crane_port,
       data_dir  => $crane_data_dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,6 +57,7 @@ class pulp::params {
   $ca_key = '/etc/pki/pulp/ca.key'
   $https_cert = $ca_cert
   $https_key = $ca_key
+  $https_ca_cert = $ca_cert
   $https_chain = undef
   $ssl_username = 'SSL_CLIENT_S_DN_CN'
   $enable_http = false

--- a/spec/classes/pulp_apache_spec.rb
+++ b/spec/classes/pulp_apache_spec.rb
@@ -33,6 +33,10 @@ describe 'pulp::apache' do
         :serveraliases           => [facts[:hostname]],
         :docroot                 => '/usr/share/pulp/wsgi',
         :ssl                     => true,
+        :ssl_cert                => '/etc/pki/pulp/ca.crt',
+        :ssl_key                 => '/etc/pki/pulp/ca.key',
+        :ssl_chain               => nil,
+        :ssl_ca                  => '/etc/pki/pulp/ca.crt',
         :ssl_verify_client       => 'optional',
         :ssl_protocol            => ['all', '-SSLv2', '-SSLv3'],
         :ssl_options             => '+StdEnvVars +ExportCertData',
@@ -42,6 +46,27 @@ describe 'pulp::apache' do
         :wsgi_daemon_process     => 'pulp user=apache group=apache processes=3 maximum-requests=0 display-name=%{GROUP}',
         :wsgi_pass_authorization => 'On',
         :wsgi_import_script      => '/usr/share/pulp/wsgi/webservices.wsgi',
+      })
+    end
+  end
+
+  context 'with https_ca_cert on ::pulp class set' do
+    let :pre_condition do
+      "class { 'pulp':
+        https_ca_cert => '/path/to/ca.crt',
+      }"
+    end
+
+    let :facts do
+      default_facts
+    end
+
+    it 'should configure apache server with ssl' do
+      is_expected.to contain_apache__vhost('pulp-https').with({
+        :ssl_cert  => '/etc/pki/pulp/ca.crt',
+        :ssl_key   => '/etc/pki/pulp/ca.key',
+        :ssl_chain => nil,
+        :ssl_ca    => '/path/to/ca.crt',
       })
     end
   end

--- a/spec/classes/pulp_child_apache_spec.rb
+++ b/spec/classes/pulp_child_apache_spec.rb
@@ -26,6 +26,11 @@ describe 'pulp::child::apache' do
             .with_max_keep_alive(10000)
             .with_ssl_username('SSL_CLIENT_S_DN_CN')
         end
+
+        it do
+          is_expected.to contain_apache__vhost('pulp-node-ssl')
+            .with_ssl_ca('/etc/pki/pulp/ca.crt')
+        end
       end
 
       describe "with explicit parameters" do


### PR DESCRIPTION
This PR allows the configuration of a different CA cert for the Apache Vhost and introduces the new parameter `https_ca_cert`. 

It's a follow up to: https://github.com/theforeman/puppet-pulp/pull/277