### PR TITLE
Fix https_ca_cert if a different location for ca_cert is used

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -81,7 +81,7 @@ class pulp::apache {
       ssl_cert                   => $pulp::https_cert,
       ssl_key                    => $pulp::https_key,
       ssl_chain                  => $pulp::https_chain,
-      ssl_ca                     => $pulp::https_ca_cert,
+      ssl_ca                     => pick($pulp::https_ca_cert, $pulp::ca_cert),
       ssl_certs_dir              => '',
       ssl_verify_client          => 'optional',
       ssl_protocol               => $pulp::ssl_protocol,

--- a/manifests/child/apache.pp
+++ b/manifests/child/apache.pp
@@ -20,6 +20,14 @@ class pulp::child::apache (
     $directories = undef
   }
 
+  if $ssl_ca {
+    $_ssl_ca = $ssl_ca
+  } elsif $::pulp::ca_cert {
+    $_ssl_ca = $::pulp::ca_cert
+  } else {
+    $_ssl_ca = $pulp::child::server_ca_cert
+  }
+
   apache::vhost { 'pulp-node-ssl':
     servername             => $servername,
     docroot                => '/var/www/html',
@@ -31,7 +39,7 @@ class pulp::child::apache (
     ssl                    => true,
     ssl_cert               => $ssl_cert,
     ssl_key                => $ssl_key,
-    ssl_ca                 => $ssl_ca,
+    ssl_ca                 => $_ssl_ca,
     ssl_certs_dir          => '',
     ssl_verify_client      => 'optional',
     ssl_options            => '+StdEnvVars',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -553,7 +553,7 @@ class pulp (
     class { 'pulp::crane':
       cert      => $https_cert,
       key       => $https_key,
-      ca_cert   => $https_ca_cert,
+      ca_cert   => pick($pulp::https_ca_cert, $pulp::ca_cert),
       ssl_chain => $https_chain,
       port      => $crane_port,
       data_dir  => $crane_data_dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,7 +57,7 @@ class pulp::params {
   $ca_key = '/etc/pki/pulp/ca.key'
   $https_cert = $ca_cert
   $https_key = $ca_key
-  $https_ca_cert = $ca_cert
+  $https_ca_cert = undef
   $https_chain = undef
   $ssl_username = 'SSL_CLIENT_S_DN_CN'
   $enable_http = false

--- a/spec/classes/pulp_apache_spec.rb
+++ b/spec/classes/pulp_apache_spec.rb
@@ -50,26 +50,6 @@ describe 'pulp::apache' do
     end
   end
 
-  context 'with https_ca_cert on ::pulp class set' do
-    let :pre_condition do
-      "class { 'pulp':
-        https_ca_cert => '/path/to/ca.crt',
-      }"
-    end
-
-    let :facts do
-      default_facts
-    end
-
-    it 'should configure apache server with ssl' do
-      is_expected.to contain_apache__vhost('pulp-https').with({
-        :ssl_cert  => '/etc/pki/pulp/ca.crt',
-        :ssl_key   => '/etc/pki/pulp/ca.key',
-        :ssl_chain => nil,
-        :ssl_ca    => '/path/to/ca.crt',
-      })
-    end
-  end
 
   context 'with parameters' do
     let :facts do
@@ -474,6 +454,40 @@ Alias /pulp/nodes/content /var/www/pulp/nodes/content
       end
 
     end
-  end
+    
+    describe 'with https_ca_cert on ::pulp class set' do
+      let :pre_condition do
+        "class { 'pulp':
+          https_ca_cert => '/path/to/https_ca.crt',
+        }"
+      end
 
+      it 'should configure apache server with ssl' do
+        is_expected.to contain_apache__vhost('pulp-https').with({
+          :ssl_cert      => '/etc/pki/pulp/ca.crt',
+          :ssl_key       => '/etc/pki/pulp/ca.key',
+          :ssl_chain     => nil,
+          :ssl_ca        => '/path/to/https_ca.crt',
+        })
+      end
+    end
+    
+    describe 'with https_ca_cert unset and ca_cert set on ::pulp class' do
+      let :pre_condition do
+        "class { 'pulp':
+          ca_cert => '/path/to/ca.crt',
+        }"
+      end
+      
+      it 'should configure apache server with ssl' do
+        is_expected.to contain_apache__vhost('pulp-https').with({
+          :ssl_cert   => '/etc/pki/pulp/ca.crt',
+          :ssl_key    => '/etc/pki/pulp/ca.key',
+          :ssl_chain  => nil,
+          :ssl_ca     => '/path/to/ca.crt',
+        })
+      end
+    end
+
+  end
 end

--- a/spec/classes/pulp_child_apache_spec.rb
+++ b/spec/classes/pulp_child_apache_spec.rb
@@ -22,7 +22,7 @@ describe 'pulp::child::apache' do
             .with_servername('foo.example.com')
             .with_ssl_cert('/etc/pki/pulp/ssl_apache.crt')
             .with_ssl_key('/etc/pki/pulp/ssl_apache.key')
-            .with_ssl_ca('/etc/pki/pulp/ca.crt')
+            .with_ssl_ca(nil)
             .with_max_keep_alive(10000)
             .with_ssl_username('SSL_CLIENT_S_DN_CN')
         end


### PR DESCRIPTION
This fixes the bug introduced here https://github.com/theforeman/puppet-pulp/pull/381 which occurs if the default path of `pulp::ca_cert` is changed. 
The root cause is that `pulp::https_ca_cert` is set to the value of `pulp::ca_cert` in `params.pp`. If the value of `pulp::ca_cert` gets changed by passing an argument to the class, we have a missmatch if `pulp::https_ca_cert` is not defined at the same time.

@ekohl do you mind taking a look at the fix?
@evgeni FYI