### PR TITLE
Move /etc/httpd/conf.d/{,10-}pulp.conf

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -125,7 +125,7 @@ class pulp::apache {
       notify  => Service['httpd'],
     }
   } else {
-    file {'/etc/httpd/conf.d/pulp.conf':
+    file {'/etc/httpd/conf.d/10-pulp.conf':
       ensure  => file,
       content => template('pulp/pulp.conf.erb'),
       owner   => 'root',

--- a/templates/server.conf.erb
+++ b/templates/server.conf.erb
@@ -123,7 +123,7 @@ rsa_pub = <%= scope['pulp::rsa_pub'] %>
 #
 # cacert: full path to the CA certificate that will be used to sign consumer
 #     and admin identification certificates; this must match the value of
-#     SSLCACertificateFile in /etc/httpd/conf.d/pulp.conf
+#     SSLCACertificateFile in /etc/httpd/conf.d/10-pulp.conf
 #     Deprecated! - Please note that both cacert and cakey settings will be
 #     removed in the next major release since Pulp will not sign certificates.
 #     However, Pulp will continue to support client certificates generated


### PR DESCRIPTION
This is to resolve https://github.com/theforeman/puppet-pulpcore/issues/49 by moving `pulp.conf` to `10-pulp.conf` so it loads after the Foreman vhost.