### PR TITLE
Always manage pulp.conf in Apache

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -8,6 +8,17 @@ class pulp::apache {
   include apache::mod::ssl
   include apache::mod::xsendfile
 
+  # This file is installed by pulp-server but we manage it ourselves.
+  # Yum/RPM will restore deleted files on upgrade so we write some dummy value
+  file {'/etc/httpd/conf.d/pulp.conf':
+    ensure  => file,
+    content => "# This file is managed by puppet, do not alter.\n",
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    notify  => Service['httpd'],
+  }
+
   if $pulp::manage_httpd {
     if $pulp::enable_http or $pulp::enable_puppet {
       apache::vhost { 'pulp-http':
@@ -113,16 +124,6 @@ class pulp::apache {
       add_default_charset        => 'UTF-8',
       # allow older yum clients to connect, see bz 647828
       custom_fragment            => 'SSLInsecureRenegotiation On',
-    }
-
-    # This file is installed by pulp-server but we have everything in the above vhost
-    file {'/etc/httpd/conf.d/pulp.conf':
-      ensure  => file,
-      content => "# This file is managed by puppet, do not alter.\n",
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
-      notify  => Service['httpd'],
     }
   } else {
     file {'/etc/httpd/conf.d/10-pulp.conf':


### PR DESCRIPTION
95422c69ef3bbbe27069505f6729d6cad3e1204a moved this file, but that will break upgrades. By blanking the file, this will not conflict.