### PR TITLE
Improve validation of ldap parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -536,10 +536,8 @@ class pulp (
     $real_yum_max_speed = undef
   }
 
-  if $ldap_url {
-    assert_type(String, $ldap_url)
-    assert_type(String, $ldap_bind_dn)
-    assert_type(String, $ldap_bind_password)
+  if $ldap_url or $ldap_bind_dn or $ldap_bind_password {
+    assert_type(Array[NotUndef], [$ldap_url, $ldap_bind_dn, $ldap_bind_password])
   }
 
   if $manage_repo {


### PR DESCRIPTION
Make sure that none of the ldap parameters are `undef` if any of them
have been set.

With this pattern, (using `NotUndef`), we avoid repeating the data types
already specified in the parameter list.